### PR TITLE
docs: fixed typo to to adhere to Google Code Style

### DIFF
--- a/src/test/java/com/codenames/codenames_backend/gameplay/ClueValidationServiceTest.java
+++ b/src/test/java/com/codenames/codenames_backend/gameplay/ClueValidationServiceTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Tests for ClueValidationService */
+/** Tests for ClueValidationService. */
 public class ClueValidationServiceTest {
   private static final int TOTAL_CARDS = 25;
   private static final int STARTING_TEAM_CARDS = 9;


### PR DESCRIPTION
### Missed one commit.

* Contains a typo fix for javadocs. Missing fullstop at the end of a sentence.