### PR TITLE
Fix/websocket join flow

### DIFF
--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -51,8 +51,6 @@ public class GameController {
 
     String sessionId = headerAccessor.getSessionId();
 
-    lobbyService.joinLobby(message.getName(), message.getCode());
-
     sessionRegistry.register(sessionId, message.getName(), message.getCode());
 
     sendPlayerUpdate(message.getCode());

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -1,10 +1,15 @@
 package com.codenames.codenames_backend.websocket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.codenames.codenames_backend.lobby.services.LobbyService;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -20,18 +25,19 @@ class GameControllerTest {
   private LobbyService lobbyService;
   private SessionRegistry sessionRegistry;
   private GameController controller;
+  private SimpMessagingTemplate messagingTemplate;
 
   @BeforeEach
   void setup() {
     lobbyService = mock(LobbyService.class);
-    SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+    messagingTemplate = mock(SimpMessagingTemplate.class);
     sessionRegistry = new SessionRegistry();
 
     controller = new GameController(lobbyService, messagingTemplate, sessionRegistry);
   }
 
   @Test
-  void shouldHandleJoinAndRegisterSession() {
+  void shouldRegisterJoinAndRegisterSession() {
 
     JoinMessage msg = new JoinMessage();
     msg.setName("Max");
@@ -40,11 +46,15 @@ class GameControllerTest {
     SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
     accessor.setSessionId("123");
 
+    when(lobbyService.getPlayers("ABCDE")).thenReturn(List.of(new Player("Max")));
+
     controller.join(msg, accessor);
 
-    verify(lobbyService).joinLobby("Max", "ABCDE");
+    verify(lobbyService, never()).joinLobby(any(), any());
 
     assertEquals("Max", sessionRegistry.getUser("123"));
     assertEquals("ABCDE", sessionRegistry.getLobby("123"));
+
+    verify(messagingTemplate).convertAndSend(eq("/topic/lobby/ABCDE"), any(Object.class));
   }
 }


### PR DESCRIPTION
## Context
Fixes duplicate player entries caused by handling lobby joins via both HTTP and STOMP.

## Description
Removed lobby join logic from GameController so that lobby state is managed exclusively via HTTP. STOMP is now only responsible for session registration and broadcasting updates.

## Changes in the codebase
- Refactored GameController (no more joinLobbycall)
- Updated GameControllerTest

## Changes outside the codebase
N/A

## Additional information
This refactor improves separation of concerns by:
- Keeping HTTP-based lobby management independent
- Using STOMP for structured real-time communication