### PR TITLE
Fix/lobby websocket sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>

--- a/src/main/java/com/codenames/codenames_backend/CodenamesBackendApplication.java
+++ b/src/main/java/com/codenames/codenames_backend/CodenamesBackendApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class CodenamesBackendApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(CodenamesBackendApplication.class, args);
-    }
-
+  public static void main(String[] args) {
+    SpringApplication.run(CodenamesBackendApplication.class, args);
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/CodenamesBackendApplication.java
+++ b/src/main/java/com/codenames/codenames_backend/CodenamesBackendApplication.java
@@ -3,9 +3,19 @@ package com.codenames.codenames_backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Main entry point for the Codenames Backend application.
+ *
+ * <p>Starts the Spring Boot application and initializes the context.
+ */
 @SpringBootApplication
 public class CodenamesBackendApplication {
 
+  /**
+   * Launches the application.
+   *
+   * @param args command-line arguments
+   */
   public static void main(String[] args) {
     SpringApplication.run(CodenamesBackendApplication.class, args);
   }

--- a/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
@@ -18,13 +18,16 @@ public class Lobby {
         this.addPlayer(username);
     }
 
-    public void addPlayer(String username) {
+    public boolean addPlayer(String username) {
         boolean alreadyExists = playerList.stream()
                 .anyMatch(p -> p.getUsername().equals(username));
 
-        if (!alreadyExists && playerList.size() < MAX_PLAYERS) {
-            playerList.add(new Player(username));
+        if (alreadyExists || playerList.size() >=MAX_PLAYERS) {
+            return false;
         }
+
+        playerList.add(new Player(username));
+        return true;
     }
 
     public void removePlayer(String username) {

--- a/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
@@ -1,36 +1,33 @@
 package com.codenames.codenames_backend.lobby;
 
 import com.codenames.codenames_backend.websocket.Player;
-import lombok.Getter;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.Getter;
 
 @Getter
 public class Lobby {
-    private static final int MAX_PLAYERS = 4;
-    private final String lobbyCode;
-    private final List<Player> playerList = new CopyOnWriteArrayList<>();
+  private static final int MAX_PLAYERS = 4;
+  private final String lobbyCode;
+  private final List<Player> playerList = new CopyOnWriteArrayList<>();
 
-    public Lobby(String lobbyCode, String username) {
-        this.lobbyCode = lobbyCode;
-        this.addPlayer(username);
+  public Lobby(String lobbyCode, String username) {
+    this.lobbyCode = lobbyCode;
+    this.addPlayer(username);
+  }
+
+  public boolean addPlayer(String username) {
+    boolean alreadyExists = playerList.stream().anyMatch(p -> p.getUsername().equals(username));
+
+    if (alreadyExists || playerList.size() >= MAX_PLAYERS) {
+      return false;
     }
 
-    public boolean addPlayer(String username) {
-        boolean alreadyExists = playerList.stream()
-                .anyMatch(p -> p.getUsername().equals(username));
+    playerList.add(new Player(username));
+    return true;
+  }
 
-        if (alreadyExists || playerList.size() >=MAX_PLAYERS) {
-            return false;
-        }
-
-        playerList.add(new Player(username));
-        return true;
-    }
-
-    public void removePlayer(String username) {
-        playerList.removeIf(p -> p.getUsername().equals(username));
-    }
+  public void removePlayer(String username) {
+    playerList.removeIf(p -> p.getUsername().equals(username));
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
@@ -5,17 +5,35 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 
+/**
+ * Represents a game lobby containing a limited number of players.
+ *
+ * <p>Supports adding and removing players while enforcing constraints such as maximum player count
+ * and unique usernames.
+ */
 @Getter
 public class Lobby {
   private static final int MAX_PLAYERS = 4;
   private final String lobbyCode;
   private final List<Player> playerList = new CopyOnWriteArrayList<>();
 
+  /**
+   * Creates a new lobby and adds the initial player.
+   *
+   * @param lobbyCode the unique code identifying the lobby
+   * @param username the username of the player creating the lobby
+   */
   public Lobby(String lobbyCode, String username) {
     this.lobbyCode = lobbyCode;
     this.addPlayer(username);
   }
 
+  /**
+   * Adds a player to the lobby if capacity allows and the username is unique.
+   *
+   * @param username the username of the player
+   * @return {@code true} if the player was added, {@code false} otherwise
+   */
   public boolean addPlayer(String username) {
     boolean alreadyExists = playerList.stream().anyMatch(p -> p.getUsername().equals(username));
 
@@ -27,6 +45,11 @@ public class Lobby {
     return true;
   }
 
+  /**
+   * Removes a player from the lobby.
+   *
+   * @param username the username of the player to remove
+   */
   public void removePlayer(String username) {
     playerList.removeIf(p -> p.getUsername().equals(username));
   }

--- a/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
@@ -5,16 +5,16 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Getter
 public class Lobby {
     private static final int MAX_PLAYERS = 4;
     private final String lobbyCode;
-    private final List<Player> playerList;
+    private final List<Player> playerList = new CopyOnWriteArrayList<>();
 
     public Lobby(String lobbyCode, String username) {
         this.lobbyCode = lobbyCode;
-        this.playerList = new ArrayList<>();
         this.addPlayer(username);
     }
 

--- a/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/Lobby.java
@@ -19,7 +19,10 @@ public class Lobby {
     }
 
     public void addPlayer(String username) {
-        if (playerList.size() < MAX_PLAYERS) {
+        boolean alreadyExists = playerList.stream()
+                .anyMatch(p -> p.getUsername().equals(username));
+
+        if (!alreadyExists && playerList.size() < MAX_PLAYERS) {
             playerList.add(new Player(username));
         }
     }

--- a/src/main/java/com/codenames/codenames_backend/lobby/controller/LobbyController.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/controller/LobbyController.java
@@ -8,16 +8,33 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST controller for handling lobby management operations.
+ *
+ * <p>Provides endpoints for creating, joining, and leaving lobbies. Delegates business logic to
+ * {@link LobbyService}.
+ */
 @RestController
 @RequestMapping("/lobby")
 public class LobbyController {
 
   private final LobbyService service;
 
+  /**
+   * Creates a new {@code LobbyController}.
+   *
+   * @param service the lobby service used to handle business logic
+   */
   public LobbyController(LobbyService service) {
     this.service = service;
   }
 
+  /**
+   * Handles a request to create a new lobby.
+   *
+   * @param username the username of the requesting user
+   * @return a response containing the result and the generated lobby code
+   */
   @PostMapping("/create")
   public ResponseEntity<LobbyResponse> createLobby(@RequestParam String username) {
     String lobbyCode = service.createLobby(username);
@@ -29,6 +46,13 @@ public class LobbyController {
     }
   }
 
+  /**
+   * Handles a request to join an existing lobby.
+   *
+   * @param username the username of the player
+   * @param lobbyCode the lobby code identifying the lobby
+   * @return a response indicating whether the join was successful
+   */
   @PostMapping("/join")
   public ResponseEntity<LobbyResponse> joinLobby(
       @RequestParam String username, @RequestParam String lobbyCode) {
@@ -41,6 +65,13 @@ public class LobbyController {
     }
   }
 
+  /**
+   * Handles a request to leave a lobby.
+   *
+   * @param username the username of the player
+   * @param lobbyCode the lobby code identifying the lobby
+   * @return a response indicating whether the operation was successful
+   */
   @PostMapping("/leave")
   public ResponseEntity<LobbyResponse> leaveLobby(
       @RequestParam String username, @RequestParam String lobbyCode) {

--- a/src/main/java/com/codenames/codenames_backend/lobby/controller/LobbyController.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/controller/LobbyController.java
@@ -12,39 +12,44 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/lobby")
 public class LobbyController {
 
-    private final LobbyService service;
+  private final LobbyService service;
 
-    public LobbyController(LobbyService service) {
-        this.service = service;
-    }
+  public LobbyController(LobbyService service) {
+    this.service = service;
+  }
 
-    @PostMapping("/create")
-    public ResponseEntity<LobbyResponse> createLobby(@RequestParam String username) {
-        String lobbyCode = service.createLobby(username);
-        if (lobbyCode.isBlank()) {
-            return ResponseEntity.internalServerError().body(new LobbyResponse("Error while creating lobby.", ""));
-        } else {
-            return ResponseEntity.ok(new LobbyResponse("Successfully created Lobby.", lobbyCode));
-        }
+  @PostMapping("/create")
+  public ResponseEntity<LobbyResponse> createLobby(@RequestParam String username) {
+    String lobbyCode = service.createLobby(username);
+    if (lobbyCode.isBlank()) {
+      return ResponseEntity.internalServerError()
+          .body(new LobbyResponse("Error while creating lobby.", ""));
+    } else {
+      return ResponseEntity.ok(new LobbyResponse("Successfully created Lobby.", lobbyCode));
     }
+  }
 
-    @PostMapping("/join")
-    public ResponseEntity<LobbyResponse> joinLobby(@RequestParam String username, @RequestParam String lobbyCode) {
-        boolean joined = service.joinLobby(username, lobbyCode);
-        if (joined) {
-            return ResponseEntity.ok(new LobbyResponse("Joined Lobby successfully.", lobbyCode));
-        } else {
-            return ResponseEntity.badRequest().body(new LobbyResponse("Could not find lobby.", lobbyCode));
-        }
+  @PostMapping("/join")
+  public ResponseEntity<LobbyResponse> joinLobby(
+      @RequestParam String username, @RequestParam String lobbyCode) {
+    boolean joined = service.joinLobby(username, lobbyCode);
+    if (joined) {
+      return ResponseEntity.ok(new LobbyResponse("Joined Lobby successfully.", lobbyCode));
+    } else {
+      return ResponseEntity.badRequest()
+          .body(new LobbyResponse("Could not find lobby.", lobbyCode));
     }
+  }
 
-    @PostMapping("/leave")
-    public ResponseEntity<LobbyResponse> leaveLobby(@RequestParam String username, @RequestParam String lobbyCode) {
-        boolean left = service.leaveLobby(username, lobbyCode);
-        if (left) {
-            return ResponseEntity.ok(new LobbyResponse("Left lobby successfully.", lobbyCode));
-        } else {
-            return ResponseEntity.badRequest().body(new LobbyResponse("Could not find lobby.", lobbyCode));
-        }
+  @PostMapping("/leave")
+  public ResponseEntity<LobbyResponse> leaveLobby(
+      @RequestParam String username, @RequestParam String lobbyCode) {
+    boolean left = service.leaveLobby(username, lobbyCode);
+    if (left) {
+      return ResponseEntity.ok(new LobbyResponse("Left lobby successfully.", lobbyCode));
+    } else {
+      return ResponseEntity.badRequest()
+          .body(new LobbyResponse("Could not find lobby.", lobbyCode));
     }
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class LobbyResponse {
-    private String message;
-    private String lobbyCode;
+  private String message;
+  private String lobbyCode;
 
-    public LobbyResponse(String message, String lobbyCode) {
-        this.lobbyCode = lobbyCode;
-        this.message = message;
-    }
+  public LobbyResponse(String message, String lobbyCode) {
+    this.lobbyCode = lobbyCode;
+    this.message = message;
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
@@ -2,11 +2,22 @@ package com.codenames.codenames_backend.lobby.dto;
 
 import lombok.Getter;
 
+/**
+ * Data transfer object representing the result of a lobby operation.
+ *
+ * <p>Contains a message describing the outcome and the associated lobby code.
+ */
 @Getter
 public class LobbyResponse {
   private final String message;
   private final String lobbyCode;
 
+  /**
+   * Creates a new lobby response.
+   *
+   * @param message the message describing the result of the operation
+   * @param lobbyCode the associated lobby code
+   */
   public LobbyResponse(String message, String lobbyCode) {
     this.lobbyCode = lobbyCode;
     this.message = message;

--- a/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/dto/LobbyResponse.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 
 @Getter
 public class LobbyResponse {
-  private String message;
-  private String lobbyCode;
+  private final String message;
+  private final String lobbyCode;
 
   public LobbyResponse(String message, String lobbyCode) {
     this.lobbyCode = lobbyCode;

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGenerator.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGenerator.java
@@ -1,25 +1,24 @@
 package com.codenames.codenames_backend.lobby.services;
 
-import org.springframework.stereotype.Service;
-
 import java.security.SecureRandom;
+import org.springframework.stereotype.Service;
 
 @Service
 public class LobbyCodeGenerator {
 
-    private static final String CHARACTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  private static final String CHARACTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
-    private static final int CODE_LENGTH = 5;
-    private static final SecureRandom RANDOM = new SecureRandom();
+  private static final int CODE_LENGTH = 5;
+  private static final SecureRandom RANDOM = new SecureRandom();
 
-    public String generateLobbyCode() {
-        StringBuilder code = new StringBuilder(CODE_LENGTH);
+  public String generateLobbyCode() {
+    StringBuilder code = new StringBuilder(CODE_LENGTH);
 
-        for (int i = 0; i < CODE_LENGTH; i++) {
-            int index = RANDOM.nextInt(CHARACTERS.length());
-            code.append(CHARACTERS.charAt(index));
-        }
-
-        return code.toString();
+    for (int i = 0; i < CODE_LENGTH; i++) {
+      int index = RANDOM.nextInt(CHARACTERS.length());
+      code.append(CHARACTERS.charAt(index));
     }
+
+    return code.toString();
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGenerator.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGenerator.java
@@ -3,6 +3,12 @@ package com.codenames.codenames_backend.lobby.services;
 import java.security.SecureRandom;
 import org.springframework.stereotype.Service;
 
+/**
+ * Utility service for generating unique lobby codes.
+ *
+ * <p>Codes consist of uppercase letters and digits, excluding ambiguous characters. Uses {@link
+ * java.security.SecureRandom} for randomness.
+ */
 @Service
 public class LobbyCodeGenerator {
 
@@ -11,6 +17,11 @@ public class LobbyCodeGenerator {
   private static final int CODE_LENGTH = 5;
   private static final SecureRandom RANDOM = new SecureRandom();
 
+  /**
+   * Generates a random lobby code.
+   *
+   * @return a newly generated lobby code
+   */
   public String generateLobbyCode() {
     StringBuilder code = new StringBuilder(CODE_LENGTH);
 

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -7,16 +7,33 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service responsible for managing lobbies and player interactions.
+ *
+ * <p>Handles creation of lobbies, player joins/leaves, and retrieval of lobby data. Ensures
+ * uniqueness of lobby codes and thread-safe access to lobby storage.
+ */
 @Service
 public class LobbyService {
 
   private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
   private final LobbyCodeGenerator generator;
 
+  /**
+   * Creates a new {@code LobbyService}.
+   *
+   * @param generator the lobby code generator used to create unique lobby codes
+   */
   public LobbyService(LobbyCodeGenerator generator) {
     this.generator = generator;
   }
 
+  /**
+   * Creates a new lobby and adds the given user as the first player.
+   *
+   * @param username the username of the player creating the lobby
+   * @return the generated lobby code, or {@code null} if creation fails
+   */
   public String createLobby(String username) {
     String lobbyCode = generateLobbyCode();
     if (lobbyCode == null || lobbyCode.isBlank()) {
@@ -27,6 +44,13 @@ public class LobbyService {
     return lobbyCode;
   }
 
+  /**
+   * Adds a player to an existing lobby.
+   *
+   * @param username the username of the player
+   * @param lobbyCode the lobby code identifying the lobby
+   * @return {@code true} if the player successfully joined, {@code false} otherwise
+   */
   public boolean joinLobby(String username, String lobbyCode) {
     Lobby lobby = lobbyList.get(lobbyCode);
     if (lobby != null) {
@@ -35,6 +59,13 @@ public class LobbyService {
     return false;
   }
 
+  /**
+   * Removes a player from a lobby.
+   *
+   * @param username the username of the player
+   * @param lobbyCode the lobby code identifying the lobby
+   * @return {@code true} if the player was removed, {@code false} if the lobby does not exist
+   */
   public boolean leaveLobby(String username, String lobbyCode) {
     Lobby lobby = lobbyList.get(lobbyCode);
     if (lobby != null) {
@@ -57,6 +88,12 @@ public class LobbyService {
     return code;
   }
 
+  /**
+   * Retrieves all players in the specified lobby.
+   *
+   * @param lobbyCode the lobby code identifying the lobby
+   * @return a list of players, or an empty list if the lobby does not exist
+   */
   public List<Player> getPlayers(String lobbyCode) {
     Lobby lobby = lobbyList.get(lobbyCode);
     return lobby != null ? lobby.getPlayerList() : List.of();

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -30,11 +30,9 @@ public class LobbyService {
     public boolean joinLobby(String username, String lobbyCode) {
         Lobby lobby = lobbyList.get(lobbyCode);
         if (lobby != null) {
-            lobby.addPlayer(username);
-            return true;
-        } else {
-            return false;
+            return lobby.addPlayer(username);
         }
+            return false;
     }
 
     public boolean leaveLobby(String username, String lobbyCode) {

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -19,7 +19,9 @@ public class LobbyService {
 
   public String createLobby(String username) {
     String lobbyCode = generateLobbyCode();
-    if (lobbyCode == null || lobbyCode.isBlank()) return null;
+    if (lobbyCode == null || lobbyCode.isBlank()) {
+      return null;
+    }
     Lobby lobby = new Lobby(lobbyCode, username);
     lobbyList.put(lobbyCode, lobby);
     return lobbyCode;

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -46,6 +46,11 @@ public class LobbyService {
 
     private String generateLobbyCode() {
         String code = generator.generateLobbyCode();
+
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+
         while (lobbyList.containsKey(code)) {
             code = generator.generateLobbyCode();
         }

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -2,63 +2,61 @@ package com.codenames.codenames_backend.lobby.services;
 
 import com.codenames.codenames_backend.lobby.Lobby;
 import com.codenames.codenames_backend.websocket.Player;
-import org.springframework.stereotype.Service;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
 
 @Service
 public class LobbyService {
 
-    private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
-    private final LobbyCodeGenerator generator;
+  private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
+  private final LobbyCodeGenerator generator;
 
-    public LobbyService(LobbyCodeGenerator generator) {
-        this.generator = generator;
+  public LobbyService(LobbyCodeGenerator generator) {
+    this.generator = generator;
+  }
+
+  public String createLobby(String username) {
+    String lobbyCode = generateLobbyCode();
+    if (lobbyCode == null || lobbyCode.isBlank()) return null;
+    Lobby lobby = new Lobby(lobbyCode, username);
+    lobbyList.put(lobbyCode, lobby);
+    return lobbyCode;
+  }
+
+  public boolean joinLobby(String username, String lobbyCode) {
+    Lobby lobby = lobbyList.get(lobbyCode);
+    if (lobby != null) {
+      return lobby.addPlayer(username);
+    }
+    return false;
+  }
+
+  public boolean leaveLobby(String username, String lobbyCode) {
+    Lobby lobby = lobbyList.get(lobbyCode);
+    if (lobby != null) {
+      lobby.removePlayer(username);
+      return true;
+    }
+    return false;
+  }
+
+  private String generateLobbyCode() {
+    String code = generator.generateLobbyCode();
+
+    if (code == null || code.isBlank()) {
+      return null;
     }
 
-    public String createLobby(String username) {
-        String lobbyCode = generateLobbyCode();
-        if (lobbyCode == null || lobbyCode.isBlank()) return null;
-        Lobby lobby = new Lobby(lobbyCode, username);
-        lobbyList.put(lobbyCode, lobby);
-        return lobbyCode;
+    while (lobbyList.containsKey(code)) {
+      code = generator.generateLobbyCode();
     }
+    return code;
+  }
 
-    public boolean joinLobby(String username, String lobbyCode) {
-        Lobby lobby = lobbyList.get(lobbyCode);
-        if (lobby != null) {
-            return lobby.addPlayer(username);
-        }
-            return false;
-    }
-
-    public boolean leaveLobby(String username, String lobbyCode) {
-        Lobby lobby = lobbyList.get(lobbyCode);
-        if (lobby != null) {
-            lobby.removePlayer(username);
-            return true;
-        }
-        return false;
-    }
-
-    private String generateLobbyCode() {
-        String code = generator.generateLobbyCode();
-
-        if (code == null || code.isBlank()) {
-            return null;
-        }
-
-        while (lobbyList.containsKey(code)) {
-            code = generator.generateLobbyCode();
-        }
-        return code;
-    }
-
-    public List<Player> getPlayers(String lobbyCode) {
-        Lobby lobby = lobbyList.get(lobbyCode);
-        return lobby != null ? lobby.getPlayerList() : List.of();
-    }
+  public List<Player> getPlayers(String lobbyCode) {
+    Lobby lobby = lobbyList.get(lobbyCode);
+    return lobby != null ? lobby.getPlayerList() : List.of();
+  }
 }

--- a/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames_backend/lobby/services/LobbyService.java
@@ -6,11 +6,13 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class LobbyService {
 
-    private final HashMap<String, Lobby> lobbyList = new HashMap<>();
+    private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
     private final LobbyCodeGenerator generator;
 
     public LobbyService(LobbyCodeGenerator generator) {

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -51,6 +51,8 @@ public class GameController {
 
     String sessionId = headerAccessor.getSessionId();
 
+    lobbyService.joinLobby(message.getName(), message.getCode());
+
     sessionRegistry.register(sessionId, message.getName(), message.getCode());
 
     sendPlayerUpdate(message.getCode());

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -51,6 +51,10 @@ public class GameController {
 
     String sessionId = headerAccessor.getSessionId();
 
+    if (sessionId == null) {
+      return;
+    }
+
     boolean joined = lobbyService.joinLobby(message.getName(), message.getCode());
 
     if (!joined) {

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -8,11 +8,10 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 /**
- * WebSocket controller responsible for handling game-related messaging.
+ * WebSocket controller for handling real-time game interactions.
  *
- * <p>Processes incoming client messages (e.g. join requests) and coordinates lobby interactions via
- * {@link LobbyService}. Also broadcasts updates to subscribed clients using {@link
- * SimpMessagingTemplate}.
+ * <p>Processes client messages (e.g. join requests), coordinates with {@link LobbyService}, and
+ * broadcasts updates to subscribed clients.
  */
 @Controller
 public class GameController {
@@ -24,9 +23,9 @@ public class GameController {
   /**
    * Creates a new {@code GameController}.
    *
-   * @param lobbyService the lobby service handling lobby logic
+   * @param lobbyService the service handling lobby operations
    * @param messagingTemplate the messaging template used for broadcasting updates
-   * @param sessionRegistry the registry tracking WebSocket sessions
+   * @param sessionRegistry the registry managing WebSocket sessions
    */
   public GameController(
       LobbyService lobbyService,
@@ -38,13 +37,13 @@ public class GameController {
   }
 
   /**
-   * Handles a join request from a client.
+   * Processes a WebSocket request to join a lobby.
    *
-   * <p>Registers the player in the lobby, associates the WebSocket session with the player and
-   * lobby, and broadcasts the updated player list to all subscribers of the lobby topic.
+   * <p>Registers the player, associates the session with the lobby, and broadcasts the updated
+   * player list to subscribers.
    *
-   * @param message the join message containing the player's name and lobby code
-   * @param headerAccessor the accessor used to retrieve WebSocket session attributes
+   * @param message the join request containing username and lobby code
+   * @param headerAccessor provides access to the WebSocket session
    */
   @MessageMapping("/join")
   public void join(JoinMessage message, SimpMessageHeaderAccessor headerAccessor) {
@@ -72,9 +71,9 @@ public class GameController {
   }
 
   /**
-   * Sends an updated list of player usernames to all clients subscribed to the lobby topic.
+   * Sends the updated list of player usernames to all clients in the lobby.
    *
-   * @param code the lobby code identifying the target lobby
+   * @param code the lobby code identifying the lobby
    */
   private void sendPlayerUpdate(String code) {
     List<String> players = lobbyService.getPlayers(code).stream().map(Player::getUsername).toList();

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -51,6 +51,10 @@ public class GameController {
 
     String sessionId = headerAccessor.getSessionId();
 
+    if (sessionId == null && headerAccessor.getSessionAttributes() != null) {
+      sessionId = (String) headerAccessor.getSessionAttributes().get("sessionId");
+    }
+
     if (sessionId == null) {
       return;
     }

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -61,7 +61,7 @@ public class GameController {
     boolean joined = lobbyService.joinLobby(message.getName(), message.getCode());
 
     if (!joined) {
-      messagingTemplate.convertAndSendToUser(sessionId, "/queue/errors", "Join failed");
+      messagingTemplate.convertAndSend("/topic/errors/" + sessionId, "Join failed");
       return;
     }
 

--- a/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/GameController.java
@@ -51,7 +51,12 @@ public class GameController {
 
     String sessionId = headerAccessor.getSessionId();
 
-    lobbyService.joinLobby(message.getName(), message.getCode());
+    boolean joined = lobbyService.joinLobby(message.getName(), message.getCode());
+
+    if (!joined) {
+      messagingTemplate.convertAndSendToUser(sessionId, "/queue/errors", "Join failed");
+      return;
+    }
 
     sessionRegistry.register(sessionId, message.getName(), message.getCode());
 

--- a/src/main/java/com/codenames/codenames_backend/websocket/JoinMessage.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/JoinMessage.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 /**
  * Message payload sent by clients to join a lobby.
  *
- * <p>Contains the player's name and the lobby code they want to join.
+ * <p>Contains the player's username and the target lobby code.
  */
 @Getter
 @Setter

--- a/src/main/java/com/codenames/codenames_backend/websocket/Player.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/Player.java
@@ -3,9 +3,9 @@ package com.codenames.codenames_backend.websocket;
 import lombok.Getter;
 
 /**
- * Represents a player connected via WebSocket.
+ * Represents a player connected to the system.
  *
- * <p>A player is identified by a username and is associated with a WebSocket session.
+ * <p>A player is identified by a username and may be associated with a WebSocket session.
  */
 @Getter
 public class Player {

--- a/src/main/java/com/codenames/codenames_backend/websocket/SessionRegistry.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/SessionRegistry.java
@@ -5,12 +5,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
 /**
- * Registry for tracking WebSocket sessions and their associated users and lobbies.
+ * Registry for managing WebSocket sessions and their associated users and lobbies.
  *
- * <p>Maintains mappings between session IDs, usernames, and lobby codes to enable efficient lookup
- * during messaging and disconnect events.
+ * <p>Maintains mappings between session IDs, usernames, and lobby codes to support messaging and
+ * cleanup on disconnect.
  *
- * <p>This implementation is thread-safe using {@link ConcurrentHashMap}.
+ * <p>This implementation is thread-safe.
  */
 @Component
 public class SessionRegistry {
@@ -18,11 +18,11 @@ public class SessionRegistry {
   private final Map<String, String> sessionToUser = new ConcurrentHashMap<>();
 
   /**
-   * Registers a WebSocket session with its associated username and lobby code.
+   * Registers a session with its associated user and lobby.
    *
    * @param sessionId the WebSocket session ID
-   * @param username the username of the connected player
-   * @param lobbyCode the lobby code the player joined
+   * @param username the username of the player
+   * @param lobbyCode the lobby code
    */
   public void register(String sessionId, String username, String lobbyCode) {
     sessionToLobby.put(sessionId, lobbyCode);
@@ -30,7 +30,7 @@ public class SessionRegistry {
   }
 
   /**
-   * Returns the lobby code associated with the given session ID.
+   * Returns the lobby code associated with the given session.
    *
    * @param sessionId the WebSocket session ID
    * @return the lobby code, or {@code null} if not found

--- a/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.codenames.codenames_backend.websocket;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -14,6 +15,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Value("${app.allowed-origins}")
+  private String[] allowedOrigins;
 
   /**
    * Configures the message broker used for routing messages between clients.
@@ -40,7 +44,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry
         .addEndpoint("/ws")
-        .setAllowedOrigins("http://localhost:8080", "http://10.0.2.2:8080")
+        .setAllowedOrigins(allowedOrigins)
         .withSockJS();
   }
 }

--- a/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
@@ -38,6 +38,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
    */
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/ws").setAllowedOrigins("http://localhost:8080").withSockJS();
+    registry
+        .addEndpoint("/ws")
+        .setAllowedOrigins("http://localhost:8080", "http://10.0.2.2:8080")
+        .withSockJS();
   }
 }

--- a/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/WebSocketConfig.java
@@ -8,9 +8,9 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 /**
- * Configuration class for WebSocket messaging using STOMP.
+ * Configuration for WebSocket communication using STOMP.
  *
- * <p>Enables a simple in-memory message broker and configures endpoints for client connections.
+ * <p>Enables a simple message broker and defines endpoints for client connections.
  */
 @Configuration
 @EnableWebSocketMessageBroker
@@ -42,9 +42,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
    */
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry
-        .addEndpoint("/ws")
-        .setAllowedOrigins(allowedOrigins)
-        .withSockJS();
+    registry.addEndpoint("/ws").setAllowedOrigins(allowedOrigins).withSockJS();
   }
 }

--- a/src/main/java/com/codenames/codenames_backend/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/codenames/codenames_backend/websocket/WebSocketEventListener.java
@@ -10,8 +10,8 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 /**
  * Listener for WebSocket lifecycle events.
  *
- * <p>Handles events such as client disconnections to ensure proper cleanup of session data and to
- * notify remaining clients in a lobby.
+ * <p>Handles client disconnections by removing players from lobbies, cleaning up session mappings,
+ * and notifying remaining clients.
  */
 @Component
 public class WebSocketEventListener {
@@ -20,11 +20,11 @@ public class WebSocketEventListener {
   private final SimpMessagingTemplate messagingTemplate;
 
   /**
-   * Creates a new {@code GameController}.
+   * Creates a new {@code WebSocketEventListener}.
    *
-   * @param lobbyService the lobby service handling lobby logic
+   * @param sessionRegistry the registry managing WebSocket sessions
+   * @param lobbyService the service handling lobby operations
    * @param messagingTemplate the messaging template used for broadcasting updates
-   * @param sessionRegistry the registry tracking WebSocket sessions
    */
   public WebSocketEventListener(
       SessionRegistry sessionRegistry,
@@ -36,12 +36,12 @@ public class WebSocketEventListener {
   }
 
   /**
-   * Handles WebSocket disconnect events.
+   * Handles a WebSocket disconnect event.
    *
-   * <p>Removes the disconnected player from the lobby, cleans up session mappings, and broadcasts
-   * the updated player list to the remaining clients in the lobby.
+   * <p>Removes the disconnected player from the lobby, cleans up session data, and broadcasts the
+   * updated player list.
    *
-   * @param event the disconnect event containing the session information
+   * @param event the disconnect event containing session information
    */
   @EventListener
   public void handleDisconnect(SessionDisconnectEvent event) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,4 @@ spring:
     name: Codenames_Backend
 
 app:
-    allowed-origins:
-      - http://localhost:8080
-      - http://10.0.2.2:8080
+    allowed-origins: "http://localhost:8080,http://10.0.2.2:8080"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: Codenames_Backend
+
+app:
+    allowed-origins:
+      - http://localhost:8080
+      - http://10.0.2.2:8080

--- a/src/test/java/com/codenames/codenames_backend/CodenamesBackendApplicationTests.java
+++ b/src/test/java/com/codenames/codenames_backend/CodenamesBackendApplicationTests.java
@@ -3,11 +3,9 @@ package com.codenames.codenames_backend;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {"app.allowed-origins=http://localhost:8080,http://10.0.2.2:8080"})
 class CodenamesBackendApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
+  @Test
+  void contextLoads() {}
 }

--- a/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
@@ -1,8 +1,10 @@
 package com.codenames.codenames_backend.lobby;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class LobbyTest {
 

--- a/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
@@ -6,10 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for {@link Lobby}.
+ *
+ * <p>Validates player management and lobby constraints.
+ */
 class LobbyTest {
 
   @Test
-  void constructor_shouldInitializeLobbyCorrectly() {
+  void constructorShouldInitializeLobbyCorrectly() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     assertEquals("ABCDE", lobby.getLobbyCode());
@@ -18,7 +23,7 @@ class LobbyTest {
   }
 
   @Test
-  void addPlayer_shouldAddPlayer() {
+  void addPlayerShouldAddPlayer() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     lobby.addPlayer("P1");
@@ -28,7 +33,7 @@ class LobbyTest {
   }
 
   @Test
-  void addPlayer_shouldNotExceedMaxPlayers() {
+  void addPlayerShouldNotExceedMaxPlayers() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     lobby.addPlayer("P1");
@@ -40,7 +45,7 @@ class LobbyTest {
   }
 
   @Test
-  void removePlayer_shouldRemovePlayer() {
+  void removePlayerShouldRemovePlayer() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     lobby.addPlayer("P1");
@@ -50,7 +55,7 @@ class LobbyTest {
   }
 
   @Test
-  void removePlayer_shouldDoNothingIfPlayerNotExists() {
+  void removePlayerShouldDoNothingIfPlayerNotExists() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     lobby.removePlayer("Ghost");
@@ -59,7 +64,7 @@ class LobbyTest {
   }
 
   @Test
-  void addPlayer_shouldNotAddDuplicatePlayer() {
+  void addPlayerShouldNotAddDuplicatePlayer() {
     Lobby lobby = new Lobby("ABCDE", "Host");
 
     boolean first = lobby.addPlayer("Max");

--- a/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/LobbyTest.java
@@ -55,4 +55,19 @@ class LobbyTest {
 
     assertEquals(1, lobby.getPlayerList().size());
   }
+
+  @Test
+  void addPlayer_shouldNotAddDuplicatePlayer() {
+    Lobby lobby = new Lobby("ABCDE", "Host");
+
+    boolean first = lobby.addPlayer("Max");
+    boolean second = lobby.addPlayer("Max");
+
+    assertTrue(first);
+    assertFalse(second);
+
+    long count = lobby.getPlayerList().stream().filter(p -> p.getUsername().equals("Max")).count();
+
+    assertEquals(1, count);
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
@@ -12,6 +12,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Tests for {@link LobbyController}.
+ *
+ * <p>Verifies REST endpoints for creating, joining, and leaving lobbies.
+ */
 @WebMvcTest(LobbyController.class)
 class LobbyControllerTest {
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
@@ -1,5 +1,10 @@
 package com.codenames.codenames_backend.lobby.controller;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.codenames.codenames_backend.lobby.services.LobbyService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,81 +12,69 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-
 @WebMvcTest(LobbyController.class)
 class LobbyControllerTest {
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @MockBean
-    private LobbyService service;
+  @MockBean private LobbyService service;
 
-    @Test
-    void createLobby_shouldReturn200() throws Exception {
-        when(service.createLobby("TestUser")).thenReturn("ABCDE");
+  @Test
+  void createLobby_shouldReturn200() throws Exception {
+    when(service.createLobby("TestUser")).thenReturn("ABCDE");
 
-        mockMvc.perform(post("/lobby/create")
-                        .param("username", "TestUser"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("Successfully created Lobby."))
-                .andExpect(jsonPath("$.lobbyCode").value("ABCDE"));
-    }
+    mockMvc
+        .perform(post("/lobby/create").param("username", "TestUser"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("Successfully created Lobby."))
+        .andExpect(jsonPath("$.lobbyCode").value("ABCDE"));
+  }
 
-    @Test
-    void createLobby_BlankLobbyCode() throws Exception {
-        when(service.createLobby("TestUser")).thenReturn("");
+  @Test
+  void createLobby_BlankLobbyCode() throws Exception {
+    when(service.createLobby("TestUser")).thenReturn("");
 
-        mockMvc.perform(post("/lobby/create")
-                        .param("username", "TestUser"))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message").value("Error while creating lobby."))
-                .andExpect(jsonPath("$.lobbyCode").value(""));
-    }
+    mockMvc
+        .perform(post("/lobby/create").param("username", "TestUser"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.message").value("Error while creating lobby."))
+        .andExpect(jsonPath("$.lobbyCode").value(""));
+  }
 
-    @Test
-    void joinLobby_shouldReturn200_whenSuccess() throws Exception {
-        when(service.joinLobby("TestUser", "ABCDE")).thenReturn(true);
+  @Test
+  void joinLobby_shouldReturn200_whenSuccess() throws Exception {
+    when(service.joinLobby("TestUser", "ABCDE")).thenReturn(true);
 
-        mockMvc.perform(post("/lobby/join")
-                        .param("username", "TestUser")
-                        .param("lobbyCode", "ABCDE"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("Joined Lobby successfully."));
-    }
+    mockMvc
+        .perform(post("/lobby/join").param("username", "TestUser").param("lobbyCode", "ABCDE"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("Joined Lobby successfully."));
+  }
 
-    @Test
-    void joinLobby_shouldReturn400_whenNotFound() throws Exception {
-        when(service.joinLobby("TestUser", "XXXXX")).thenReturn(false);
+  @Test
+  void joinLobby_shouldReturn400_whenNotFound() throws Exception {
+    when(service.joinLobby("TestUser", "XXXXX")).thenReturn(false);
 
-        mockMvc.perform(post("/lobby/join")
-                        .param("username", "TestUser")
-                        .param("lobbyCode", "XXXXX"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Could not find lobby."));
-    }
+    mockMvc
+        .perform(post("/lobby/join").param("username", "TestUser").param("lobbyCode", "XXXXX"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Could not find lobby."));
+  }
 
-    @Test
-    void leaveLobby_shouldReturn200_whenSuccess() throws Exception {
-        when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(true);
+  @Test
+  void leaveLobby_shouldReturn200_whenSuccess() throws Exception {
+    when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(true);
 
-        mockMvc.perform(post("/lobby/leave")
-                        .param("username", "TestUser")
-                        .param("lobbyCode", "ABCDE"))
-                .andExpect(status().isOk());
-    }
+    mockMvc
+        .perform(post("/lobby/leave").param("username", "TestUser").param("lobbyCode", "ABCDE"))
+        .andExpect(status().isOk());
+  }
 
-    @Test
-    void leaveLobby_noSuccess() throws Exception {
-        when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(false);
+  @Test
+  void leaveLobby_noSuccess() throws Exception {
+    when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(false);
 
-        mockMvc.perform(post("/lobby/leave")
-                        .param("username", "TestUser")
-                        .param("lobbyCode", "ABCDE"))
-                .andExpect(status().isBadRequest());
-    }
+    mockMvc
+        .perform(post("/lobby/leave").param("username", "TestUser").param("lobbyCode", "ABCDE"))
+        .andExpect(status().isBadRequest());
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/controller/LobbyControllerTest.java
@@ -19,7 +19,7 @@ class LobbyControllerTest {
   @MockBean private LobbyService service;
 
   @Test
-  void createLobby_shouldReturn200() throws Exception {
+  void createLobbyShouldReturn200() throws Exception {
     when(service.createLobby("TestUser")).thenReturn("ABCDE");
 
     mockMvc
@@ -30,7 +30,7 @@ class LobbyControllerTest {
   }
 
   @Test
-  void createLobby_BlankLobbyCode() throws Exception {
+  void createLobbyBlankLobbyCode() throws Exception {
     when(service.createLobby("TestUser")).thenReturn("");
 
     mockMvc
@@ -41,7 +41,7 @@ class LobbyControllerTest {
   }
 
   @Test
-  void joinLobby_shouldReturn200_whenSuccess() throws Exception {
+  void joinLobbyShouldReturn200WhenSuccess() throws Exception {
     when(service.joinLobby("TestUser", "ABCDE")).thenReturn(true);
 
     mockMvc
@@ -51,7 +51,7 @@ class LobbyControllerTest {
   }
 
   @Test
-  void joinLobby_shouldReturn400_whenNotFound() throws Exception {
+  void joinLobbyShouldReturn400WhenNotFound() throws Exception {
     when(service.joinLobby("TestUser", "XXXXX")).thenReturn(false);
 
     mockMvc
@@ -61,7 +61,7 @@ class LobbyControllerTest {
   }
 
   @Test
-  void leaveLobby_shouldReturn200_whenSuccess() throws Exception {
+  void leaveLobbyShouldReturn200WhenSuccess() throws Exception {
     when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(true);
 
     mockMvc
@@ -70,7 +70,7 @@ class LobbyControllerTest {
   }
 
   @Test
-  void leaveLobby_noSuccess() throws Exception {
+  void leaveLobbyNoSuccess() throws Exception {
     when(service.leaveLobby("TestUser", "ABCDE")).thenReturn(false);
 
     mockMvc

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
@@ -6,17 +6,17 @@ import org.junit.jupiter.api.Test;
 
 class LobbyCodeGeneratorTest {
 
-    private LobbyCodeGenerator generator;
+  private LobbyCodeGenerator generator;
 
-    @BeforeEach
-    void setup() {
-        this.generator = new LobbyCodeGenerator();
-    }
+  @BeforeEach
+  void setup() {
+    this.generator = new LobbyCodeGenerator();
+  }
 
-    @Test
-    void testCodeGeneration_ReturnsStringOfCodeSize() {
-        String result = this.generator.generateLobbyCode();
+  @Test
+  void testCodeGeneration_ReturnsStringOfCodeSize() {
+    String result = this.generator.generateLobbyCode();
 
-        Assertions.assertEquals(5, result.length());
-    }
+    Assertions.assertEquals(5, result.length());
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
@@ -4,6 +4,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for {@link LobbyCodeGenerator}.
+ *
+ * <p>Ensures that generated lobby codes meet expected constraints.
+ */
 class LobbyCodeGeneratorTest {
 
   private LobbyCodeGenerator generator;

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyCodeGeneratorTest.java
@@ -14,7 +14,7 @@ class LobbyCodeGeneratorTest {
   }
 
   @Test
-  void testCodeGeneration_ReturnsStringOfCodeSize() {
+  void testCodeGenerationReturnsStringOfCodeSize() {
     String result = this.generator.generateLobbyCode();
 
     Assertions.assertEquals(5, result.length());

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
@@ -25,7 +25,7 @@ class LobbyServiceTest {
   }
 
   @Test
-  void createLobby_ReturnLobbyCode() {
+  void createLobbyReturnLobbyCode() {
     when(generator.generateLobbyCode()).thenReturn("ABCDE");
     lobbyService.createLobby("Host");
     boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
@@ -37,7 +37,7 @@ class LobbyServiceTest {
   }
 
   @Test
-  void createLobby_LobbyCodeIsNull() {
+  void createLobbyLobbyCodeIsNull() {
     when(generator.generateLobbyCode()).thenReturn(null);
     String result = lobbyService.createLobby("Host");
 
@@ -45,7 +45,7 @@ class LobbyServiceTest {
   }
 
   @Test
-  void createLobby_LobbyCodeIsBlank() {
+  void createLobbyLobbyCodeIsBlank() {
     when(generator.generateLobbyCode()).thenReturn("");
     String result = lobbyService.createLobby("Host");
 
@@ -53,13 +53,13 @@ class LobbyServiceTest {
   }
 
   @Test
-  void joinLobby_ReturnFalse_LobbyNotExists() {
+  void joinLobbyReturnFalseLobbyNotExists() {
     boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
     assertFalse(result);
   }
 
   @Test
-  void leaveLobby_ReturnTrue_LobbyExists() {
+  void leaveLobbyReturnTrueLobbyExists() {
     when(generator.generateLobbyCode()).thenReturn("ABCDE");
     lobbyService.createLobby("Host");
 
@@ -73,13 +73,13 @@ class LobbyServiceTest {
   }
 
   @Test
-  void leaveLobby_ReturnFalse_LobbyNotExists() {
+  void leaveLobbyReturnFalseLobbyNotExists() {
     boolean result = lobbyService.leaveLobby("Host", "ABCDE");
     assertFalse(result);
   }
 
   @Test
-  void createLobby_shouldGenerateNewCode_ifDuplicateExists() {
+  void createLobbyShouldGenerateNewCodeIfDuplicateExists() {
     when(generator.generateLobbyCode())
         .thenReturn("ABCDE") // erster Versuch
         .thenReturn("ABCDE") // zweiter Versuch
@@ -92,7 +92,7 @@ class LobbyServiceTest {
   }
 
   @Test
-  void getPlayers_shouldReturnEmptyList_whenLobbyDoesNotExist() {
+  void getPlayersShouldReturnEmptyListWhenLobbyDoesNotExist() {
     List<Player> players = lobbyService.getPlayers("UNKNOWN");
 
     assertNotNull(players);
@@ -100,7 +100,7 @@ class LobbyServiceTest {
   }
 
   @Test
-  void joinLobby_shouldReturnFalse_whenPlayerAlreadyExists() {
+  void joinLobbyShouldReturnFalseWhenPlayerAlreadyExists() {
     when(generator.generateLobbyCode()).thenReturn("ABCDE");
 
     lobbyService.createLobby("Host");

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
@@ -1,14 +1,17 @@
 package com.codenames.codenames_backend.lobby.services;
 
-import com.codenames.codenames_backend.websocket.Player;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.codenames.codenames_backend.websocket.Player;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class LobbyServiceTest {
 

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
@@ -13,6 +13,11 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for {@link LobbyService}.
+ *
+ * <p>Validates lobby creation, joining, leaving, and player management behavior.
+ */
 class LobbyServiceTest {
 
   private LobbyService lobbyService;

--- a/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames_backend/lobby/services/LobbyServiceTest.java
@@ -12,87 +12,106 @@ import static org.mockito.Mockito.when;
 
 class LobbyServiceTest {
 
-    private LobbyService lobbyService;
-    private LobbyCodeGenerator generator;
+  private LobbyService lobbyService;
+  private LobbyCodeGenerator generator;
 
-    @BeforeEach
-    void setup() {
-        generator = mock(LobbyCodeGenerator.class);
-        lobbyService = new LobbyService(generator);
-    }
+  @BeforeEach
+  void setup() {
+    generator = mock(LobbyCodeGenerator.class);
+    lobbyService = new LobbyService(generator);
+  }
 
-    @Test
-    void createLobby_ReturnLobbyCode() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
-        lobbyService.createLobby("Host");
-        boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
+  @Test
+  void createLobby_ReturnLobbyCode() {
+    when(generator.generateLobbyCode()).thenReturn("ABCDE");
+    lobbyService.createLobby("Host");
+    boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
 
-        assertTrue(result);
+    assertTrue(result);
 
-        List<Player> players = lobbyService.getPlayers("ABCDE");
-        assertTrue(players.stream().anyMatch(p -> p.getUsername().equals("TestUser")));
-    }
+    List<Player> players = lobbyService.getPlayers("ABCDE");
+    assertTrue(players.stream().anyMatch(p -> p.getUsername().equals("TestUser")));
+  }
 
-    @Test
-    void createLobby_LobbyCodeIsNull() {
-        when(generator.generateLobbyCode()).thenReturn(null);
-        String result = lobbyService.createLobby("Host");
+  @Test
+  void createLobby_LobbyCodeIsNull() {
+    when(generator.generateLobbyCode()).thenReturn(null);
+    String result = lobbyService.createLobby("Host");
 
-        assertNull(result);
-    }
+    assertNull(result);
+  }
 
-    @Test
-    void createLobby_LobbyCodeIsBlank() {
-        when(generator.generateLobbyCode()).thenReturn("");
-        String result = lobbyService.createLobby("Host");
+  @Test
+  void createLobby_LobbyCodeIsBlank() {
+    when(generator.generateLobbyCode()).thenReturn("");
+    String result = lobbyService.createLobby("Host");
 
-        assertNull(result);
-    }
+    assertNull(result);
+  }
 
-    @Test
-    void joinLobby_ReturnFalse_LobbyNotExists() {
-        boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
-        assertFalse(result);
-    }
+  @Test
+  void joinLobby_ReturnFalse_LobbyNotExists() {
+    boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
+    assertFalse(result);
+  }
 
-    @Test
-    void leaveLobby_ReturnTrue_LobbyExists() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
-        lobbyService.createLobby("Host");
+  @Test
+  void leaveLobby_ReturnTrue_LobbyExists() {
+    when(generator.generateLobbyCode()).thenReturn("ABCDE");
+    lobbyService.createLobby("Host");
 
-        boolean result = lobbyService.leaveLobby("Host", "ABCDE");
+    boolean result = lobbyService.leaveLobby("Host", "ABCDE");
 
-        assertTrue(result);
+    assertTrue(result);
 
-        List<Player> players = lobbyService.getPlayers("ABCDE");
+    List<Player> players = lobbyService.getPlayers("ABCDE");
 
-        assertFalse(players.stream().anyMatch(p -> p.getUsername().equals("Host")));
-    }
+    assertFalse(players.stream().anyMatch(p -> p.getUsername().equals("Host")));
+  }
 
-    @Test
-    void leaveLobby_ReturnFalse_LobbyNotExists() {
-        boolean result = lobbyService.leaveLobby("Host", "ABCDE");
-        assertFalse(result);
-    }
+  @Test
+  void leaveLobby_ReturnFalse_LobbyNotExists() {
+    boolean result = lobbyService.leaveLobby("Host", "ABCDE");
+    assertFalse(result);
+  }
 
-    @Test
-    void createLobby_shouldGenerateNewCode_ifDuplicateExists() {
-        when(generator.generateLobbyCode())
-                .thenReturn("ABCDE") // erster Versuch
-                .thenReturn("ABCDE") // zweiter Versuch
-                .thenReturn("FGHIJ"); // dritter Versuch - anderes Ergebnis
+  @Test
+  void createLobby_shouldGenerateNewCode_ifDuplicateExists() {
+    when(generator.generateLobbyCode())
+        .thenReturn("ABCDE") // erster Versuch
+        .thenReturn("ABCDE") // zweiter Versuch
+        .thenReturn("FGHIJ"); // dritter Versuch - anderes Ergebnis
 
-        lobbyService.createLobby("Host1");
-        String code2 = lobbyService.createLobby("Host2");
+    lobbyService.createLobby("Host1");
+    String code2 = lobbyService.createLobby("Host2");
 
-        assertEquals("FGHIJ", code2);
-    }
+    assertEquals("FGHIJ", code2);
+  }
 
-    @Test
-    void getPlayers_shouldReturnEmptyList_whenLobbyDoesNotExist() {
-        List<Player> players = lobbyService.getPlayers("UNKNOWN");
+  @Test
+  void getPlayers_shouldReturnEmptyList_whenLobbyDoesNotExist() {
+    List<Player> players = lobbyService.getPlayers("UNKNOWN");
 
-        assertNotNull(players);
-        assertTrue(players.isEmpty());
-    }
+    assertNotNull(players);
+    assertTrue(players.isEmpty());
+  }
+
+  @Test
+  void joinLobby_shouldReturnFalse_whenPlayerAlreadyExists() {
+    when(generator.generateLobbyCode()).thenReturn("ABCDE");
+
+    lobbyService.createLobby("Host");
+
+    boolean first = lobbyService.joinLobby("Max", "ABCDE");
+    boolean second = lobbyService.joinLobby("Max", "ABCDE");
+
+    assertTrue(first);
+    assertFalse(second);
+
+    List<Player> players = lobbyService.getPlayers("ABCDE");
+
+    long count = players.stream().filter(p -> p.getUsername().equals("Max")).count();
+
+    assertEquals(1, count);
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames_backend.lobby.services.LobbyService;
@@ -62,4 +63,27 @@ class GameControllerTest {
 
     verify(messagingTemplate).convertAndSend(eq("/topic/lobby/ABCDE"), any(Object.class));
   }
+
+  @Test
+  void shouldSendErrorMessage_whenJoinFails() {
+
+    JoinMessage msg = new JoinMessage();
+    msg.setName("Max");
+    msg.setCode("ABCDE");
+
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+
+    java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+    attrs.put("sessionId", "123");
+    accessor.setSessionAttributes(attrs);
+
+    when(lobbyService.joinLobby("Max", "ABCDE")).thenReturn(false);
+
+    controller.join(msg, accessor);
+
+    verify(messagingTemplate).convertAndSendToUser("123", "/queue/errors", "Join failed");
+
+    verifyNoMoreInteractions(messagingTemplate);
+  }
+  
 }

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -44,13 +44,16 @@ class GameControllerTest {
     msg.setCode("ABCDE");
 
     SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
-    accessor.setSessionId("123");
+    accessor.setSessionAttributes(new java.util.HashMap<>());
+    accessor.getSessionAttributes().put("sessionId", "123");
+
+    when(lobbyService.joinLobby("Max", "ABCDE")).thenReturn(true);
 
     when(lobbyService.getPlayers("ABCDE")).thenReturn(List.of(new Player("Max")));
 
     controller.join(msg, accessor);
 
-    verify(lobbyService, never()).joinLobby(any(), any());
+    verify(lobbyService).joinLobby("Max", "ABCDE");
 
     assertEquals("Max", sessionRegistry.getUser("123"));
     assertEquals("ABCDE", sessionRegistry.getLobby("123"));

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,8 +43,11 @@ class GameControllerTest {
     msg.setCode("ABCDE");
 
     SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
-    accessor.setSessionAttributes(new java.util.HashMap<>());
-    accessor.getSessionAttributes().put("sessionId", "123");
+
+    java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+    attrs.put("sessionId", "123");
+
+    accessor.setSessionAttributes(attrs);
 
     when(lobbyService.joinLobby("Max", "ABCDE")).thenReturn(true);
 

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -85,5 +86,19 @@ class GameControllerTest {
 
     verifyNoMoreInteractions(messagingTemplate);
   }
-  
+
+  @Test
+  void shouldDoNothing_whenSessionIdIsNull() {
+
+    JoinMessage msg = new JoinMessage();
+    msg.setName("Max");
+    msg.setCode("ABCDE");
+
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+
+    controller.join(msg, accessor);
+
+    verifyNoInteractions(lobbyService);
+    verifyNoInteractions(messagingTemplate);
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -101,4 +101,29 @@ class GameControllerTest {
     verifyNoInteractions(lobbyService);
     verifyNoInteractions(messagingTemplate);
   }
+
+  @Test
+  void shouldUseSessionAttributesFallback_whenSessionIdIsNull() {
+
+    JoinMessage msg = new JoinMessage();
+    msg.setName("Max");
+    msg.setCode("ABCDE");
+
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+
+    java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+    attrs.put("sessionId", "123");
+    accessor.setSessionAttributes(attrs);
+
+    when(lobbyService.joinLobby("Max", "ABCDE")).thenReturn(true);
+    when(lobbyService.getPlayers("ABCDE")).thenReturn(List.of(new Player("Max")));
+
+    controller.join(msg, accessor);
+
+    assertEquals("Max", sessionRegistry.getUser("123"));
+    assertEquals("ABCDE", sessionRegistry.getLobby("123"));
+
+    verify(lobbyService).joinLobby("Max", "ABCDE");
+    verify(messagingTemplate).convertAndSend(eq("/topic/lobby/ABCDE"), any(Object.class));
+  }
 }

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -82,7 +82,7 @@ class GameControllerTest {
 
     controller.join(msg, accessor);
 
-    verify(messagingTemplate).convertAndSendToUser("123", "/queue/errors", "Join failed");
+    verify(messagingTemplate).convertAndSend("/topic/errors/123", "Join failed");
 
     verifyNoMoreInteractions(messagingTemplate);
   }

--- a/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/GameControllerTest.java
@@ -66,7 +66,7 @@ class GameControllerTest {
   }
 
   @Test
-  void shouldSendErrorMessage_whenJoinFails() {
+  void shouldSendErrorMessageWhenJoinFails() {
 
     JoinMessage msg = new JoinMessage();
     msg.setName("Max");
@@ -88,7 +88,7 @@ class GameControllerTest {
   }
 
   @Test
-  void shouldDoNothing_whenSessionIdIsNull() {
+  void shouldDoNothingWhenSessionIdIsNull() {
 
     JoinMessage msg = new JoinMessage();
     msg.setName("Max");
@@ -103,7 +103,7 @@ class GameControllerTest {
   }
 
   @Test
-  void shouldUseSessionAttributesFallback_whenSessionIdIsNull() {
+  void shouldUseSessionAttributesFallbackWhenSessionIdIsNull() {
 
     JoinMessage msg = new JoinMessage();
     msg.setName("Max");

--- a/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
@@ -28,14 +28,16 @@ class WebSocketConfigTest {
     WebSocketConfig config = new WebSocketConfig();
 
     StompEndpointRegistry registry = mock(StompEndpointRegistry.class);
+
     var endpointRegistration =
         mock(
             org.springframework.web.socket.config.annotation.StompWebSocketEndpointRegistration
                 .class);
-    var sockJsRegistration =
-        mock(org.springframework.web.socket.config.annotation.SockJsServiceRegistration.class);
 
     when(registry.addEndpoint("/ws")).thenReturn(endpointRegistration);
+
+    var sockJsRegistration =
+        mock(org.springframework.web.socket.config.annotation.SockJsServiceRegistration.class);
 
     String[] origins = new String[] {"http://localhost:8080", "http://10.0.2.2:8080"};
 

--- a/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
@@ -1,5 +1,6 @@
 package com.codenames.codenames_backend.websocket;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,14 +36,16 @@ class WebSocketConfigTest {
         mock(org.springframework.web.socket.config.annotation.SockJsServiceRegistration.class);
 
     when(registry.addEndpoint("/ws")).thenReturn(endpointRegistration);
-    when(endpointRegistration.setAllowedOrigins("http://localhost:8080"))
+
+    when(endpointRegistration.setAllowedOrigins(any(String[].class)))
         .thenReturn(endpointRegistration);
+
     when(endpointRegistration.withSockJS()).thenReturn(sockJsRegistration);
 
     config.registerStompEndpoints(registry);
 
     verify(registry).addEndpoint("/ws");
-    verify(endpointRegistration).setAllowedOrigins("http://localhost:8080");
+    verify(endpointRegistration).setAllowedOrigins("http://localhost:8080", "http://10.0.2.2:8080");
     verify(endpointRegistration).withSockJS();
   }
 }

--- a/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
@@ -1,6 +1,5 @@
 package com.codenames.codenames_backend.websocket;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/codenames/codenames_backend/websocket/WebSocketConfigTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 
 /** Unit tests for {@link WebSocketConfig}. */
@@ -37,15 +38,18 @@ class WebSocketConfigTest {
 
     when(registry.addEndpoint("/ws")).thenReturn(endpointRegistration);
 
-    when(endpointRegistration.setAllowedOrigins(any(String[].class)))
-        .thenReturn(endpointRegistration);
+    String[] origins = new String[] {"http://localhost:8080", "http://10.0.2.2:8080"};
+
+    ReflectionTestUtils.setField(config, "allowedOrigins", origins);
+
+    when(endpointRegistration.setAllowedOrigins(origins)).thenReturn(endpointRegistration);
 
     when(endpointRegistration.withSockJS()).thenReturn(sockJsRegistration);
 
     config.registerStompEndpoints(registry);
 
     verify(registry).addEndpoint("/ws");
-    verify(endpointRegistration).setAllowedOrigins("http://localhost:8080", "http://10.0.2.2:8080");
+    verify(endpointRegistration).setAllowedOrigins(origins);
     verify(endpointRegistration).withSockJS();
   }
 }


### PR DESCRIPTION
## Context
This PR fixes inconsistencies in the WebSocket-based lobby join flow and aligns the implementation with the expected runtime behavior.

## Description
The previous implementation of the WebSocket join handler had issues with session handling and incomplete lobby synchronization. In certain scenarios (especially in tests), the session ID was not correctly resolved, causing the join logic to exit early and preventing players from being registered properly.

Additionally, the join flow relied on assumptions about external REST calls, which led to inconsistent lobby state handling. This PR ensures that the WebSocket join handler is self-contained and reliable.

## Changes in the codebase 
- Improve session ID handling to support both runtime and test environments
- Prevent early return when session ID is missing by introducing a fallback via session attributes
- Remove potential NullPointerException when setting session attributes
- Make lobby join handling idempotent to prevent duplicate players when using both HTTP and WebSocket
- Ensure thread-safe lobby state management via centralized LobbyService
- Allow safe rejoin via WebSocket in case a player was unintentionally disconnected