### PR TITLE
Feature/2 operative chat

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
@@ -1,9 +1,13 @@
 package com.codenames.codenames.backend.chat;
 
+import com.codenames.codenames.backend.lobby.services.LobbyService;
+import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
+import com.codenames.codenames.backend.websocket.SessionRegistry;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 /**
@@ -16,14 +20,45 @@ import org.springframework.stereotype.Controller;
 public class ChatController {
 
   private final ChatService chatService;
+  private final LobbyService lobbyService;
+  private final SessionRegistry sessionRegistry;
 
   /**
    * Constructor for the ChatController.
    *
    * @param chatService the service used to validate and persist chat history
    */
-  public ChatController(ChatService chatService) {
+  public ChatController(
+      ChatService chatService, LobbyService lobbyService, SessionRegistry sessionRegistry) {
     this.chatService = chatService;
+    this.lobbyService = lobbyService;
+    this.sessionRegistry = sessionRegistry;
+  }
+
+  /**
+   * Verifies the username of the sender and checks if they are sending the message to their own
+   * lobby before allowing them to send a message.
+   *
+   * @param headerAccessor the header accessor containing the session information of the sender
+   * @param targetLobbyId the actual lobby ID associated with the sender's session, used to verify
+   *     that they are sending the message to their own lobby
+   * @return the username if sender is verified, otherwise throws an exception
+   * @throws IllegalStateException if the username is null or if the sender is trying to send a
+   *     message to a lobby they are not in
+   */
+  private String getVerifiedUsername(
+      SimpMessageHeaderAccessor headerAccessor, String targetLobbyId) {
+    String sessionId = headerAccessor.getSessionId();
+    String realUsername = sessionRegistry.getUser(sessionId);
+    String realLobbyId = sessionRegistry.getLobby(sessionId);
+
+    if (realUsername == null) {
+      throw new IllegalStateException("Null username.");
+    }
+    if (!targetLobbyId.equals(realLobbyId)) {
+      throw new IllegalStateException("Wrong lobby, user not in lobby " + realLobbyId);
+    }
+    return realUsername;
   }
 
   /**
@@ -33,12 +68,19 @@ public class ChatController {
    * @param chatDto the message to be sent
    */
   @MessageMapping("/chat/{lobbyId}")
-  public void sendLobbyMessage(@DestinationVariable String lobbyId, @Payload ChatDto chatDto) {
-    chatService.processMessage(lobbyId, "LOBBY", "", chatDto);
+  public void sendLobbyMessage(
+      @DestinationVariable String lobbyId,
+      @Payload ChatDto chatDto,
+      SimpMessageHeaderAccessor headerAccessor) {
+    String realUsername = getVerifiedUsername(headerAccessor, lobbyId);
+
+    // Create a new ChatDto with the verified username to prevent passing false username
+    ChatDto verifiedChatDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+    chatService.processMessage(lobbyId, "LOBBY", "", verifiedChatDto);
   }
 
   /**
-   * Sends a message to the entire team.
+   * Verifies the sender's name, lobbyID, and team before sending a message to the entire team.
    *
    * @param lobbyId the ID of the lobby the client is in
    * @param team the team the client is in (RED, BLUE)
@@ -48,14 +90,25 @@ public class ChatController {
   public void sendTeamMessage(
       @DestinationVariable String lobbyId,
       @DestinationVariable Team team,
-      @Payload ChatDto chatDto) {
+      @Payload ChatDto chatDto,
+      SimpMessageHeaderAccessor headerAccessor) {
+    String realUsername = getVerifiedUsername(headerAccessor, lobbyId);
+
+    Team playerTeam = lobbyService.getPlayerTeam(realUsername, lobbyId);
+    if (playerTeam != team) {
+      throw new IllegalStateException("You are not on team " + team.name());
+    }
+
+    ChatDto verifiedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+
     String roomKey = "TEAM_" + team.name();
     String topicSuffix = "/" + team.name();
-    chatService.processMessage(lobbyId, roomKey, topicSuffix, chatDto);
+    chatService.processMessage(lobbyId, roomKey, topicSuffix, verifiedDto);
   }
 
   /**
-   * Sends a message to the operatives on the respective team.
+   * Verifies the sender's name, lobbyID, team and role sending a message to the operatives on the
+   * respective team.
    *
    * @param lobbyId the ID of the lobby the client is in
    * @param team the team the client is in (RED, BLUE)
@@ -65,9 +118,21 @@ public class ChatController {
   public void sendTeamOperativeMessage(
       @DestinationVariable String lobbyId,
       @DestinationVariable Team team,
-      @Payload ChatDto chatDto) {
+      @Payload ChatDto chatDto,
+      SimpMessageHeaderAccessor headerAccessor) {
+    String realUsername = getVerifiedUsername(headerAccessor, lobbyId);
+
+    Team playerTeam = lobbyService.getPlayerTeam(realUsername, lobbyId);
+    Role playerRole = lobbyService.getPlayerRole(realUsername, lobbyId);
+
+    if (playerTeam != team || playerRole != Role.OPERATIVE) {
+      throw new SecurityException("You do not have operative access for team " + team.name());
+    }
+
+    ChatDto verifiedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+
     String roomKey = "OPERATIVE_" + team.name();
     String topicSuffix = "/" + team.name() + "/operative";
-    chatService.processMessage(lobbyId, roomKey, topicSuffix, chatDto);
+    chatService.processMessage(lobbyId, roomKey, topicSuffix, verifiedDto);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
@@ -54,5 +54,20 @@ public class ChatController {
     chatService.processMessage(lobbyId, roomKey, topicSuffix, chatDto);
   }
 
+  /**
+   * Sends a message to the operatives on the respective team.
+   *
+   * @param lobbyId the ID of the lobby the client is in
+   * @param team the team the client is in (RED, BLUE)
+   * @param chatDto the message to be sent
+   */
+  @MessageMapping("/chat/{lobbyId}/{team}/operative")
+  public void sendTeamOperativeMessage(
+      @DestinationVariable String lobbyId,
+      @DestinationVariable Team team,
+      @Payload ChatDto chatDto) {
+    String roomKey = "OPERATIVE_" + team.name();
+    String topicSuffix = "/" + team.name() + "/operative";
+    chatService.processMessage(lobbyId, roomKey, topicSuffix, chatDto);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
@@ -55,6 +55,9 @@ public class ChatController {
     if (realUsername == null) {
       throw new IllegalStateException("Null username.");
     }
+    if (targetLobbyId == null) {
+      throw new IllegalStateException("Null lobby ID.");
+    }
     if (!targetLobbyId.equals(realLobbyId)) {
       throw new IllegalStateException("Wrong lobby, user not in lobby " + realLobbyId);
     }

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
@@ -126,7 +126,8 @@ public class ChatController {
     Role playerRole = lobbyService.getPlayerRole(realUsername, lobbyId);
 
     if (playerTeam != team || playerRole != Role.OPERATIVE) {
-      throw new SecurityException("You do not have operative access for team " + team.name());
+      throw new IllegalStateException(
+          "You are either not an operative or are sending to the wrong team.");
     }
 
     ChatDto verifiedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatController.java
@@ -27,28 +27,32 @@ public class ChatController {
   }
 
   /**
-   * Sends a message to all players in the same lobby.
+   * Sends a message to the entire lobby.
    *
-   * @param lobbyId the ID of where the message is broadcasted to
-   * @param chatDto the message of the client in chatDto format
+   * @param lobbyId the ID of the lobby the client is in
+   * @param chatDto the message to be sent
    */
   @MessageMapping("/chat/{lobbyId}")
   public void sendLobbyMessage(@DestinationVariable String lobbyId, @Payload ChatDto chatDto) {
-    chatService.processLobbyMessage(lobbyId, chatDto);
+    chatService.processMessage(lobbyId, "LOBBY", "", chatDto);
   }
 
   /**
-   * Sends a message to all players in the same lobby and on the same team.
+   * Sends a message to the entire team.
    *
-   * @param lobbyId the ID of where the message is broadcasted to
-   * @param team the team of the client who calls the method
-   * @param chatDto the message of the client in chatDto format
+   * @param lobbyId the ID of the lobby the client is in
+   * @param team the team the client is in (RED, BLUE)
+   * @param chatDto the message to be sent
    */
   @MessageMapping("/chat/{lobbyId}/{team}")
   public void sendTeamMessage(
       @DestinationVariable String lobbyId,
       @DestinationVariable Team team,
       @Payload ChatDto chatDto) {
-    chatService.processTeamMessage(lobbyId, team, chatDto);
+    String roomKey = "TEAM_" + team.name();
+    String topicSuffix = "/" + team.name();
+    chatService.processMessage(lobbyId, roomKey, topicSuffix, chatDto);
+  }
+
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatDto.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatDto.java
@@ -1,5 +1,7 @@
 package com.codenames.codenames.backend.chat;
 
+import com.codenames.codenames.backend.utility.ChatMessageType;
+
 /**
  * Record class for messages that is used in controller.
  *
@@ -7,10 +9,4 @@ package com.codenames.codenames.backend.chat;
  * @param content the content of the message
  * @param type the type of message
  */
-public record ChatDto(String senderUsername, String content, MessageType type) {
-
-  /** Various message types that can be used in the game. */
-  public enum MessageType {
-    CHAT
-  }
-}
+public record ChatDto(String senderUsername, String content, ChatMessageType type) {}

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatHistory.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatHistory.java
@@ -1,62 +1,34 @@
 package com.codenames.codenames.backend.chat;
 
-import com.codenames.codenames.backend.utility.Team;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 
-/**
- * Manages the different message logs for a single lobby, this includes the lobby and both team
- * chats.
- */
+/** Manages the different message logs for a lobby. */
 @Getter
 public class ChatHistory {
   private static final int MAX_MESSAGES = 50;
-  private final List<ChatDto> lobbyChat = new CopyOnWriteArrayList<>();
-  private final List<ChatDto> redTeamChat = new CopyOnWriteArrayList<>();
-  private final List<ChatDto> blueTeamChat = new CopyOnWriteArrayList<>();
+
+  private final Map<String, List<ChatDto>> chatLogs = new ConcurrentHashMap<>();
 
   /**
-   * Adds a message to the lobby chat history.
+   * Adds a message to the specified chat room history.
    *
+   * @param roomKey the unique identifier for the chat room (lobby, team color, role)
    * @param chatDto the message to add
    */
-  public void addLobbyMessage(ChatDto chatDto) {
-    addMessage(lobbyChat, chatDto);
-  }
-
-  /**
-   * Adds a message to the team chat history.
-   *
-   * @param team the color of the team ("RED" or "BLUE")
-   * @param chatDto the message to add
-   * @throws IllegalArgumentException if the team name is not recognized
-   */
-  public void addTeamMessage(Team team, ChatDto chatDto) {
-    if (team == null) {
-      throw new IllegalArgumentException("Team cannot be null");
+  public void addMessage(String roomKey, ChatDto chatDto) {
+    if (roomKey == null || roomKey.isBlank()) {
+      throw new IllegalArgumentException("Room key cannot be null or empty");
     }
-    switch (team) {
-      case RED:
-        addMessage(redTeamChat, chatDto);
-        break;
-      case BLUE:
-        addMessage(blueTeamChat, chatDto);
-        break;
-        // google code style accepts switches as exhaustive if all enums are in the switch.
-    }
-  }
 
-  /**
-   * Helper method to make the limit is not exceeded. This to save memory.
-   *
-   * @param target the list where the message is to be saved
-   * @param chatDto the message to append
-   */
-  private void addMessage(List<ChatDto> target, ChatDto chatDto) {
-    target.add(chatDto);
-    if (target.size() > MAX_MESSAGES) {
-      target.remove(0);
+    List<ChatDto> targetLog = chatLogs.computeIfAbsent(roomKey, k -> new CopyOnWriteArrayList<>());
+
+    targetLog.add(chatDto);
+    if (targetLog.size() > MAX_MESSAGES) {
+      targetLog.remove(0);
     }
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/chat/ChatService.java
+++ b/src/main/java/com/codenames/codenames/backend/chat/ChatService.java
@@ -1,6 +1,5 @@
 package com.codenames.codenames.backend.chat;
 
-import com.codenames.codenames.backend.utility.Team;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
@@ -12,9 +11,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class ChatService {
   private final SimpMessagingTemplate messagingTemplate;
-  // Each lobby now stores 3 COWAL
+  // Contains all chat history for all lobbies
   private final Map<String, ChatHistory> lobbyChatHistory = new ConcurrentHashMap<>();
 
+  /**
+   * Constructor for ChatService.
+   *
+   * @param messagingTemplate the template for broadcasting
+   */
   public ChatService(SimpMessagingTemplate messagingTemplate) {
     this.messagingTemplate = messagingTemplate;
   }
@@ -32,43 +36,37 @@ public class ChatService {
   }
 
   /**
-   * Validates and saves a message fin the lobby chat history logs.
+   * Validates, stores, and broadcasts a message to a specific topic.
    *
-   * @param lobbyId the ID of the lobby
+   * @param lobbyId the ID of the lobby for map across all lobbies
+   * @param roomKey the internal key used to store history (e.g., "LOBBY", "TEAM_RED") per lobby
+   * @param destinationTopic the specific STOMP topic suffix to broadcast to
    * @param chatDto the message to process and store
-   * @throws IllegalArgumentException if validation fails
+   * @throws IllegalArgumentException invalid chatDto or when lobbyId/roomKey are null or empty
    */
-  public void processLobbyMessage(String lobbyId, ChatDto chatDto) {
+  public void processMessage(
+      String lobbyId, String roomKey, String destinationTopic, ChatDto chatDto) {
     try {
       validateDto(chatDto);
+
+      if (lobbyId == null || lobbyId.trim().isEmpty()) {
+        log.error("Attempted to process message for invalid lobbyId.");
+        throw new IllegalArgumentException("Lobby ID cannot be null or empty");
+      }
+
+      if (roomKey == null || roomKey.trim().isEmpty()) {
+        log.error("Invalid roomKey: null or empty");
+        throw new IllegalArgumentException("roomKey cannot be null or empty");
+      }
 
       ChatHistory currentLobbyChat =
           lobbyChatHistory.computeIfAbsent(lobbyId, k -> new ChatHistory());
-      currentLobbyChat.addLobbyMessage(chatDto);
-      messagingTemplate.convertAndSend("/topic/chat/" + lobbyId, chatDto);
-    } catch (IllegalArgumentException e) {
-      log.error("Invalid lobby message: {}", e.getMessage());
-    }
-  }
 
-  /**
-   * Validates and saves a message fin the team chat history logs.
-   *
-   * @param lobbyId the ID of the lobby
-   * @param team the color of the team ("RED" or "BLUE")
-   * @param chatDto the message to process and store
-   * @throws IllegalArgumentException if validation fails
-   */
-  public void processTeamMessage(String lobbyId, Team team, ChatDto chatDto) {
-    try {
-      validateDto(chatDto);
+      currentLobbyChat.addMessage(roomKey, chatDto);
 
-      ChatHistory currentTeamChat =
-          lobbyChatHistory.computeIfAbsent(lobbyId, k -> new ChatHistory());
-      currentTeamChat.addTeamMessage(team, chatDto);
-      messagingTemplate.convertAndSend("/topic/chat/" + lobbyId + "/" + team.name(), chatDto);
+      messagingTemplate.convertAndSend("/topic/chat/" + lobbyId + destinationTopic, chatDto);
     } catch (IllegalArgumentException e) {
-      log.error("Invalid team message: {}", e.getMessage());
+      log.error("Invalid chat message for room {}: {}", roomKey, e.getMessage());
     }
   }
 

--- a/src/main/java/com/codenames/codenames/backend/lobby/services/LobbyService.java
+++ b/src/main/java/com/codenames/codenames/backend/lobby/services/LobbyService.java
@@ -153,4 +153,34 @@ public class LobbyService {
     }
     return code;
   }
+
+  /**
+   * Retrieves the team of a player in a lobby.
+   *
+   * @param username the username of a player
+   * @param lobbyCode the lobby code of the lobby
+   * @return the team of the player, or {@code null} if the lobby or player does not exist
+   */
+  public Team getPlayerTeam(String username, String lobbyCode) {
+    Lobby lobby = lobbyList.get(lobbyCode);
+    if (lobby != null) {
+      return lobby.getPlayerTeam(username);
+    }
+    return null;
+  }
+
+  /**
+   * Retrieves the role of a player in a lobby.
+   *
+   * @param username the username of a player
+   * @param lobbyCode the lobby code of the lobby
+   * @return the role of the player, or {@code null} if the lobby or player does not exist
+   */
+  public Role getPlayerRole(String username, String lobbyCode) {
+    Lobby lobby = lobbyList.get(lobbyCode);
+    if (lobby != null) {
+      return lobby.getPlayerRole(username);
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/codenames/codenames/backend/utility/ChatMessageType.java
+++ b/src/main/java/com/codenames/codenames/backend/utility/ChatMessageType.java
@@ -1,0 +1,8 @@
+package com.codenames.codenames.backend.utility;
+
+/**
+ * Enum representing the type of chat message.
+ */
+public enum ChatMessageType {
+  CHAT
+}

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
@@ -4,12 +4,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.codenames.codenames.backend.chat.ChatDto.MessageType;
+import com.codenames.codenames.backend.utility.ChatMessageType;
 import com.codenames.codenames.backend.utility.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Unit test for Board. */
+/** Unit test for ChatController. */
 class ChatControllerTest {
   private ChatController chatController;
   private ChatService chatService;
@@ -25,7 +25,7 @@ class ChatControllerTest {
     chatController = new ChatController(chatService);
 
     lobbyId = "123";
-    chatDto = new ChatDto("TestName", "TestMessage", MessageType.CHAT);
+    chatDto = new ChatDto("TestName", "TestMessage", ChatMessageType.CHAT);
 
     redTeam = Team.RED;
     blueTeam = Team.BLUE;
@@ -35,20 +35,20 @@ class ChatControllerTest {
   void testSendLobbyMessage() {
     chatController.sendLobbyMessage(lobbyId, chatDto);
 
-    verify(chatService, times(1)).processLobbyMessage(lobbyId, chatDto);
+    verify(chatService, times(1)).processMessage(lobbyId, "LOBBY", "", chatDto);
   }
 
   @Test
   void testSendTeamMessage_redTeam() {
     chatController.sendTeamMessage(lobbyId, redTeam, chatDto);
 
-    verify(chatService, times(1)).processTeamMessage(lobbyId, redTeam, chatDto);
+    verify(chatService, times(1)).processMessage(lobbyId, "TEAM_RED", "/RED", chatDto);
   }
 
   @Test
-  void testSendTeamMessage_blueTeam() {
-    chatController.sendTeamMessage(lobbyId, blueTeam, chatDto);
+  void testSendTeamOperativeMessage_blueTeam() {
+    chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto);
 
-    verify(chatService, times(1)).processTeamMessage(lobbyId, blueTeam, chatDto);
+    verify(chatService, times(1)).processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", chatDto);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
@@ -1,20 +1,31 @@
 package com.codenames.codenames.backend.chat;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.lobby.services.LobbyService;
 import com.codenames.codenames.backend.utility.ChatMessageType;
+import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
+import com.codenames.codenames.backend.websocket.SessionRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 
 /** Unit test for ChatController. */
 class ChatControllerTest {
   private ChatController chatController;
   private ChatService chatService;
+  private SessionRegistry sessionRegistry;
+  private LobbyService lobbyService;
+  private SimpMessageHeaderAccessor headerAccessor;
 
-  private String lobbyId;
+  private final String sessionId = "session123";
+  private final String lobbyId = "lobby123";
+  private final String realUsername = "verifiedTest";
   private Team redTeam;
   private Team blueTeam;
   private ChatDto chatDto;
@@ -22,9 +33,12 @@ class ChatControllerTest {
   @BeforeEach
   void setUp() {
     chatService = mock(ChatService.class);
-    chatController = new ChatController(chatService);
+    sessionRegistry = mock(SessionRegistry.class);
+    lobbyService = mock(LobbyService.class);
+    headerAccessor = mock(SimpMessageHeaderAccessor.class);
 
-    lobbyId = "123";
+    chatController = new ChatController(chatService, lobbyService, sessionRegistry);
+
     chatDto = new ChatDto("TestName", "TestMessage", ChatMessageType.CHAT);
 
     redTeam = Team.RED;
@@ -32,24 +46,79 @@ class ChatControllerTest {
   }
 
   @Test
-  void testSendLobbyMessage() {
-    chatController.sendLobbyMessage(lobbyId, chatDto);
+  void testSendLobbyMessage_valid() {
+    chatController.sendLobbyMessage(lobbyId, chatDto, headerAccessor);
 
-    verify(chatService, times(1)).processMessage(lobbyId, "LOBBY", "", chatDto);
+    ChatDto verifiedChatDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+    verify(chatService, times(1)).processMessage(lobbyId, "LOBBY", "", verifiedChatDto);
   }
 
   @Test
-  void testSendTeamMessage_redTeam() {
-    chatController.sendTeamMessage(lobbyId, redTeam, chatDto);
+  void testSendLobbyMessage_nullUsername() {
+    when(sessionRegistry.getUser(sessionId)).thenReturn(null);
 
-    verify(chatService, times(1)).processMessage(lobbyId, "TEAM_RED", "/RED", chatDto);
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendLobbyMessage(lobbyId, chatDto, headerAccessor));
   }
 
   @Test
-  void testSendTeamOperativeMessage_blueTeam() {
-    chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto);
+  void testSendLobbyMessage_wrongLobby() {
+    when(sessionRegistry.getLobby(sessionId)).thenReturn("differentLobby");
 
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendLobbyMessage(lobbyId, chatDto, headerAccessor));
+  }
+
+  @Test
+  void testSendTeamMessage_valid() {
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.RED);
+
+    chatController.sendTeamMessage(lobbyId, Team.RED, chatDto, headerAccessor);
+
+    ChatDto expectedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+    verify(chatService, times(1)).processMessage(lobbyId, "TEAM_RED", "/RED", expectedDto);
+  }
+
+  @Test
+  void testSendTeamMessage_sendToDifferentTeam_throwException() {
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendTeamMessage(lobbyId, Team.RED, chatDto, headerAccessor));
+  }
+
+  @Test
+  void testSendTeamOperativeMessage_valid() {
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+    when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.OPERATIVE);
+
+    chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor);
+
+    ChatDto expectedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
     verify(chatService, times(1))
-        .processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", chatDto);
+        .processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", expectedDto);
+  }
+
+  @Test
+  void testSendTeamOperativeMessage_wrongRoleCorrectTeam() {
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+    when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.SPYMASTER);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor));
+  }
+
+  @Test
+  void testSendTeamOperativeMessage_wrongTeamCorrectRole() {
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.OPERATIVE);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor));
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
@@ -41,6 +41,10 @@ class ChatControllerTest {
 
     chatDto = new ChatDto("TestName", "TestMessage", ChatMessageType.CHAT);
 
+    when(headerAccessor.getSessionId()).thenReturn(sessionId);
+    when(sessionRegistry.getUser(sessionId)).thenReturn(realUsername);
+    when(sessionRegistry.getLobby(sessionId)).thenReturn(lobbyId);
+
     redTeam = Team.RED;
     blueTeam = Team.BLUE;
   }
@@ -73,52 +77,52 @@ class ChatControllerTest {
 
   @Test
   void testSendTeamMessage_valid() {
-    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(redTeam);
 
-    chatController.sendTeamMessage(lobbyId, Team.RED, chatDto, headerAccessor);
+    chatController.sendTeamMessage(lobbyId, redTeam, chatDto, headerAccessor);
 
-    ChatDto expectedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
-    verify(chatService, times(1)).processMessage(lobbyId, "TEAM_RED", "/RED", expectedDto);
+    ChatDto verifiedChatDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+    verify(chatService, times(1)).processMessage(lobbyId, "TEAM_RED", "/RED", verifiedChatDto);
   }
 
   @Test
   void testSendTeamMessage_sendToDifferentTeam_throwException() {
-    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(blueTeam);
 
     assertThrows(
         IllegalStateException.class,
-        () -> chatController.sendTeamMessage(lobbyId, Team.RED, chatDto, headerAccessor));
+        () -> chatController.sendTeamMessage(lobbyId, redTeam, chatDto, headerAccessor));
   }
 
   @Test
   void testSendTeamOperativeMessage_valid() {
-    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(blueTeam);
     when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.OPERATIVE);
 
-    chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor);
+    chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto, headerAccessor);
 
-    ChatDto expectedDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
+    ChatDto verifiedChatDto = new ChatDto(realUsername, chatDto.content(), chatDto.type());
     verify(chatService, times(1))
-        .processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", expectedDto);
+        .processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", verifiedChatDto);
   }
 
   @Test
   void testSendTeamOperativeMessage_wrongRoleCorrectTeam() {
-    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.BLUE);
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(blueTeam);
     when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.SPYMASTER);
 
     assertThrows(
         IllegalStateException.class,
-        () -> chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor));
+        () -> chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto, headerAccessor));
   }
 
   @Test
   void testSendTeamOperativeMessage_wrongTeamCorrectRole() {
-    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerTeam(realUsername, lobbyId)).thenReturn(redTeam);
     when(lobbyService.getPlayerRole(realUsername, lobbyId)).thenReturn(Role.OPERATIVE);
 
     assertThrows(
         IllegalStateException.class,
-        () -> chatController.sendTeamOperativeMessage(lobbyId, Team.BLUE, chatDto, headerAccessor));
+        () -> chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto, headerAccessor));
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
@@ -49,6 +49,7 @@ class ChatControllerTest {
   void testSendTeamOperativeMessage_blueTeam() {
     chatController.sendTeamOperativeMessage(lobbyId, blueTeam, chatDto);
 
-    verify(chatService, times(1)).processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", chatDto);
+    verify(chatService, times(1))
+        .processMessage(lobbyId, "OPERATIVE_BLUE", "/BLUE/operative", chatDto);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatControllerTest.java
@@ -74,6 +74,14 @@ class ChatControllerTest {
         IllegalStateException.class,
         () -> chatController.sendLobbyMessage(lobbyId, chatDto, headerAccessor));
   }
+  @Test
+  void testSendLobbyMessage_nullLobby() {
+    when(sessionRegistry.getLobby(sessionId)).thenReturn("differentLobby");
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> chatController.sendLobbyMessage(null, chatDto, headerAccessor));
+  }
 
   @Test
   void testSendTeamMessage_valid() {

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.codenames.codenames.backend.utility.ChatMessageType;
-import com.codenames.codenames.backend.utility.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,9 +11,9 @@ import org.junit.jupiter.api.Test;
 class ChatHistoryTest {
   private ChatDto message;
   private ChatHistory chatHistory;
-  private String lobbyRoomKey = "LOBBY";
-  private String teamRedRoomKey = "TEAM_RED";
-  private String teamBlueRoomKey = "TEAM_BLUE";
+  private final String lobbyRoomKey = "LOBBY";
+  private final String teamRedRoomKey = "TEAM_RED";
+  private final String teamBlueRoomKey = "TEAM_BLUE";
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
@@ -31,16 +31,16 @@ class ChatHistoryTest {
 
   @Test
   void testAddTeamMessage_red() {
-    chatHistory.addMessage("TEAM_RED", message);
+    chatHistory.addMessage(teamRedRoomKey, message);
 
-    assertEquals(1, chatHistory.getChatLogs().get("TEAM_RED").size());
+    assertEquals(1, chatHistory.getChatLogs().get(teamRedRoomKey).size());
   }
 
   @Test
   void testAddTeamMessage_blue() {
-    chatHistory.addMessage("TEAM_BLUE", message);
+    chatHistory.addMessage(teamBlueRoomKey, message);
 
-    assertEquals(1, chatHistory.getChatLogs().get("TEAM_BLUE").size());
+    assertEquals(1, chatHistory.getChatLogs().get(teamBlueRoomKey).size());
   }
 
   @Test
@@ -56,8 +56,8 @@ class ChatHistoryTest {
   @Test
   void testAddMessage_exceedCapacity() {
     for (int i = 1; i <= 51; i++) {
-      chatHistory.addMessage("LOBBY", message);
+      chatHistory.addMessage(lobbyRoomKey, message);
     }
-    assertEquals(50, chatHistory.getChatLogs().get("LOBBY").size());
+    assertEquals(50, chatHistory.getChatLogs().get(lobbyRoomKey).size());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatHistoryTest.java
@@ -3,7 +3,7 @@ package com.codenames.codenames.backend.chat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.codenames.codenames.backend.chat.ChatDto.MessageType;
+import com.codenames.codenames.backend.utility.ChatMessageType;
 import com.codenames.codenames.backend.utility.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,44 +12,52 @@ import org.junit.jupiter.api.Test;
 class ChatHistoryTest {
   private ChatDto message;
   private ChatHistory chatHistory;
+  private String lobbyRoomKey = "LOBBY";
+  private String teamRedRoomKey = "TEAM_RED";
+  private String teamBlueRoomKey = "TEAM_BLUE";
 
   @BeforeEach
   void setUp() {
     chatHistory = new ChatHistory();
-    message = new ChatDto("TestName", "TestMessage", MessageType.CHAT);
+    message = new ChatDto("TestName", "TestMessage", ChatMessageType.CHAT);
   }
 
   @Test
   void testAddLobbyMessage() {
-    chatHistory.addLobbyMessage(message);
+    chatHistory.addMessage(lobbyRoomKey, message);
 
-    assertEquals(1, chatHistory.getLobbyChat().size());
+    assertEquals(1, chatHistory.getChatLogs().size());
   }
 
   @Test
   void testAddTeamMessage_red() {
-    chatHistory.addTeamMessage(Team.RED, message);
+    chatHistory.addMessage("TEAM_RED", message);
 
-    assertEquals(1, chatHistory.getRedTeamChat().size());
+    assertEquals(1, chatHistory.getChatLogs().get("TEAM_RED").size());
   }
 
   @Test
   void testAddTeamMessage_blue() {
-    chatHistory.addTeamMessage(Team.BLUE, message);
+    chatHistory.addMessage("TEAM_BLUE", message);
 
-    assertEquals(1, chatHistory.getBlueTeamChat().size());
+    assertEquals(1, chatHistory.getChatLogs().get("TEAM_BLUE").size());
   }
 
   @Test
-  void testAddTeamMessage_nullTeam() {
-    assertThrows(IllegalArgumentException.class, () -> chatHistory.addTeamMessage(null, message));
+  void testAddTeamMessage_nullRoomKey() {
+    assertThrows(IllegalArgumentException.class, () -> chatHistory.addMessage(null, message));
+  }
+
+  @Test
+  void testAddTeamMessage_blankRoomKey() {
+    assertThrows(IllegalArgumentException.class, () -> chatHistory.addMessage("", message));
   }
 
   @Test
   void testAddMessage_exceedCapacity() {
     for (int i = 1; i <= 51; i++) {
-      chatHistory.addLobbyMessage(message);
+      chatHistory.addMessage("LOBBY", message);
     }
-    assertEquals(50, chatHistory.getLobbyChat().size());
+    assertEquals(50, chatHistory.getChatLogs().get("LOBBY").size());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatServiceTest.java
@@ -3,7 +3,6 @@ package com.codenames.codenames.backend.chat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -100,7 +99,7 @@ class ChatServiceTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void testProcessMessage_invalidroomKey(String input) {
+  void testProcessMessage_invalidRoomKey(String input) {
     chatService.processMessage(lobbyId, input, "", message);
     verify(messagingTemplate, never()).convertAndSend("/topic/chat/" + lobbyId, message);
   }

--- a/src/test/java/com/codenames/codenames/backend/chat/ChatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/chat/ChatServiceTest.java
@@ -3,12 +3,13 @@ package com.codenames.codenames.backend.chat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.codenames.codenames.backend.chat.ChatDto.MessageType;
+import com.codenames.codenames.backend.utility.ChatMessageType;
 import com.codenames.codenames.backend.utility.Team;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 /** Unit tests for ChatService. */
@@ -25,52 +27,45 @@ class ChatServiceTest {
   private Team team;
   private ChatService chatService;
   private SimpMessagingTemplate messagingTemplate;
+  private final String lobbyRoomKey = "LOBBY";
+  private final String teamRoomKey = "TEAM_";
 
   private static Stream<Arguments> provideInvalidChatDto() {
     return Stream.of(
-        arguments(new ChatDto(null, "TestMessage", MessageType.CHAT)),
-        arguments(new ChatDto("", "TestMessage", MessageType.CHAT)),
-        arguments(new ChatDto("TestName", null, MessageType.CHAT)),
-        arguments(new ChatDto("TestName", "", MessageType.CHAT)),
+        arguments(new ChatDto(null, "TestMessage", ChatMessageType.CHAT)),
+        arguments(new ChatDto("", "TestMessage", ChatMessageType.CHAT)),
+        arguments(new ChatDto("TestName", null, ChatMessageType.CHAT)),
+        arguments(new ChatDto("TestName", "", ChatMessageType.CHAT)),
         arguments(new ChatDto("TestName", "TestMessage", null)));
   }
 
   @BeforeEach
   void setUp() {
-    lobbyId = "TESTLOBBY";
+    lobbyId = "123";
     team = Team.RED;
     messagingTemplate = mock(SimpMessagingTemplate.class);
     chatService = new ChatService(messagingTemplate);
-    message = new ChatDto("TestName", "TestMessage", MessageType.CHAT);
+    message = new ChatDto("TestName", "TestMessage", ChatMessageType.CHAT);
   }
 
-  @ParameterizedTest(name = "[{index}] Rejects {0}")
+  @ParameterizedTest
   @MethodSource("provideInvalidChatDto")
-  void testLobbyValidationLogic_invalidMessages(ChatDto invalidMessage) {
-    chatService.processLobbyMessage(lobbyId, invalidMessage);
+  void testProcessMessage_invalidMessages(ChatDto invalidMessage) {
+    chatService.processMessage(lobbyId, lobbyRoomKey, "", invalidMessage);
 
     verify(messagingTemplate, never()).convertAndSend("/topic/chat/" + lobbyId, message);
   }
 
-  @ParameterizedTest(name = "[{index}] Rejects {0}")
-  @MethodSource("provideInvalidChatDto")
-  void testTeamValidationLogic_invalidMessages(ChatDto invalidMessage) {
-    chatService.processTeamMessage(lobbyId, team, invalidMessage);
-
-    verify(messagingTemplate, never())
-        .convertAndSend("/topic/chat/" + lobbyId + "/" + team.name(), message);
-  }
-
   @Test
   void testProcessLobbyMessage() {
-    chatService.processLobbyMessage(lobbyId, message);
+    chatService.processMessage(lobbyId, lobbyRoomKey, "", message);
 
     verify(messagingTemplate, times(1)).convertAndSend("/topic/chat/" + lobbyId, message);
   }
 
   @Test
   void testProcessTeamMessage() {
-    chatService.processTeamMessage(lobbyId, team, message);
+    chatService.processMessage(lobbyId, teamRoomKey + team.name(), "/" + team.name(), message);
 
     verify(messagingTemplate, times(1))
         .convertAndSend("/topic/chat/" + lobbyId + "/" + team.name(), message);
@@ -78,7 +73,7 @@ class ChatServiceTest {
 
   @Test
   void testClearLobbyHistory() {
-    chatService.processLobbyMessage(lobbyId, message);
+    chatService.processMessage(lobbyId, lobbyRoomKey, "", message);
     chatService.clearLobbyHistory(lobbyId);
 
     assertThrows(IllegalArgumentException.class, () -> chatService.getChatHistory(lobbyId));
@@ -86,13 +81,28 @@ class ChatServiceTest {
 
   @Test
   void testGetChatHistory() {
-    chatService.processLobbyMessage(lobbyId, message);
+    chatService.processMessage(lobbyId, lobbyRoomKey, "", message);
 
-    assertEquals(message, chatService.getChatHistory(lobbyId).getLobbyChat().get(0));
+    assertEquals(message, chatService.getChatHistory(lobbyId).getChatLogs().get("LOBBY").get(0));
   }
 
   @Test
   void testGetChatHistory_noMessageYet() {
     assertThrows(IllegalArgumentException.class, () -> chatService.getChatHistory(lobbyId));
   }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void testProcessMessage_invalidLobbyId(String input) {
+    chatService.processMessage(input, lobbyRoomKey, "", message);
+    verify(messagingTemplate, never()).convertAndSend("/topic/chat/" + lobbyId, message);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void testProcessMessage_invalidroomKey(String input) {
+    chatService.processMessage(lobbyId, input, "", message);
+    verify(messagingTemplate, never()).convertAndSend("/topic/chat/" + lobbyId, message);
+  }
+
 }

--- a/src/test/java/com/codenames/codenames/backend/clue/ClueValidationServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/clue/ClueValidationServiceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/** Unit tests for ClueValidationService */
+/** Unit tests for ClueValidationService. */
 class ClueValidationServiceTest {
   private static final int TOTAL_CARDS = 25;
   private static final int STARTING_TEAM_CARDS = 9;

--- a/src/test/java/com/codenames/codenames/backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/services/LobbyServiceTest.java
@@ -184,5 +184,43 @@ class LobbyServiceTest {
 
         assertEquals(1, count);
     }
+  @Test
+  void testGetPlayerTeam(){
+    lobbyService.createLobby("Host");
+    lobbyService.selectPosition("Host", "ABCDE", Team.RED, Role.SPYMASTER);
 
+    assertEquals(Team.RED, lobbyService.getPlayerTeam("Host", "ABCDE"));
+  }
+
+  @Test
+  void getPlayerTeam_wrongCode() {
+    assertNull(lobbyService.getPlayerTeam("Host", "invalidCode"));
+  }
+
+  @Test
+  void getPlayerTeam_nonExistentPlayer() {
+    String lobbyCode = lobbyService.createLobby("Host");
+
+    assertNull(lobbyService.getPlayerTeam("nonExistentPlayer", lobbyCode));
+  }
+
+  @Test
+  void testGetPlayerRole(){
+    lobbyService.createLobby("Host");
+    lobbyService.selectPosition("Host", "ABCDE", Team.RED, Role.OPERATIVE);
+
+    assertEquals(Role.OPERATIVE, lobbyService.getPlayerRole("Host", "ABCDE"));
+  }
+
+  @Test
+  void getPlayerRole_wrongCode() {
+    assertNull(lobbyService.getPlayerRole("Host", "test"));
+  }
+
+  @Test
+  void getPlayerRole_nonExistentPlayer() {
+    String lobbyCode = lobbyService.createLobby("Host");
+
+    assertNull(lobbyService.getPlayerRole("nonExistentPlayer", lobbyCode));
+  }
 }

--- a/src/test/java/com/codenames/codenames/backend/lobby/services/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/services/LobbyServiceTest.java
@@ -29,11 +29,11 @@ class LobbyServiceTest {
     void setup() {
         generator = mock(LobbyCodeGenerator.class);
         lobbyService = new LobbyService(generator);
+      when(generator.generateLobbyCode()).thenReturn("ABCDE");
     }
 
     @Test
     void createLobby_ReturnLobbyCode() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
         boolean result = lobbyService.joinLobby("TestUser", "ABCDE");
 
@@ -67,7 +67,6 @@ class LobbyServiceTest {
 
     @Test
     void leaveLobby_ReturnTrue_LobbyExists() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
 
         boolean result = lobbyService.leaveLobby("Host", "ABCDE");
@@ -100,7 +99,6 @@ class LobbyServiceTest {
 
     @Test
     void selectPosition_shouldReturnTrue_WhenPlayerChoosesTeamAndRole() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
 
         boolean result = lobbyService.selectPosition("Host", "ABCDE", Team.RED, Role.SPYMASTER);
@@ -117,7 +115,6 @@ class LobbyServiceTest {
 
     @Test
     void selectPosition_shouldReturnFalse_WhenPlayerIsNotInLobby() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
 
         boolean result = lobbyService.selectPosition("Ghost", "ABCDE", Team.RED, Role.SPYMASTER);
@@ -127,7 +124,6 @@ class LobbyServiceTest {
 
     @Test
     void selectPosition_shouldReturnFalse_WhenSecondSpymasterChoosesSameTeam() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
         lobbyService.joinLobby("P1", "ABCDE");
 
@@ -140,7 +136,6 @@ class LobbyServiceTest {
 
     @Test
     void selectPosition_shouldReturnTrue_WhenSpymastersChooseDifferentTeams() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
         lobbyService.joinLobby("P1", "ABCDE");
 
@@ -153,7 +148,6 @@ class LobbyServiceTest {
 
     @Test
     void selectPosition_shouldReturnTrue_WhenMultipleOperativesChooseSameTeam() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
         lobbyService.createLobby("Host");
         lobbyService.joinLobby("P1", "ABCDE");
 
@@ -174,8 +168,6 @@ class LobbyServiceTest {
 
     @Test
     void joinLobbyShouldReturnFalseWhenPlayerAlreadyExists() {
-        when(generator.generateLobbyCode()).thenReturn("ABCDE");
-
         lobbyService.createLobby("Host");
 
         boolean first = lobbyService.joinLobby("Max", "ABCDE");
@@ -192,4 +184,5 @@ class LobbyServiceTest {
 
         assertEquals(1, count);
     }
+
 }

--- a/src/test/java/com/codenames/codenames/backend/playingfield/CardGeneratorTest.java
+++ b/src/test/java/com/codenames/codenames/backend/playingfield/CardGeneratorTest.java
@@ -28,16 +28,10 @@ class CardGeneratorTest {
     List<Card> cards = cardGenerator.generateCards(total, red, blue, white, black);
 
     assertEquals(total, cards.size());
-
-    long redAmount = cards.stream().filter(card -> card.getColor() == Color.RED).count();
-    long blueAmount = cards.stream().filter(card -> card.getColor() == Color.BLUE).count();
-    long whiteAmount = cards.stream().filter(card -> card.getColor() == Color.WHITE).count();
-    long blackAmount = cards.stream().filter(card -> card.getColor() == Color.BLACK).count();
-
-    assertEquals(red, redAmount);
-    assertEquals(blue, blueAmount);
-    assertEquals(white, whiteAmount);
-    assertEquals(black, blackAmount);
+    assertEquals(red, cards.stream().filter(card -> card.getColor() == Color.RED).count());
+    assertEquals(blue, cards.stream().filter(card -> card.getColor() == Color.BLUE).count());
+    assertEquals(white, cards.stream().filter(card -> card.getColor() == Color.WHITE).count());
+    assertEquals(black, cards.stream().filter(card -> card.getColor() == Color.BLACK).count());
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/playingfield/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/playingfield/GameManagerTest.java
@@ -236,7 +236,7 @@ class GameManagerTest {
   }
 
   @Test
-  void testGetCurrentClueWordNullUponInitializaiton(){
+  void testGetCurrentClueWordNullUponInitialization() {
     assertNull(gameManager.getCurrentClueWord());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.playingfield.Card;
-import com.codenames.codenames.backend.utility.Color;
 import com.codenames.codenames.backend.playingfield.GameManager;
+import com.codenames.codenames.backend.utility.Color;
 import com.codenames.codenames.backend.utility.Role;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -35,7 +35,8 @@ class SerializationJsonTest {
   void testSerialize_pass() {
     String expectedResult =
         "{\"winner\":\"RED\",\"currentTurn\":\"RED\",\"currentRedFound\":0,\"currentBlueFound\":0"
-            + ",\"currentClue\":\"Test\",\"remainingGuesses\":1,\"cardList\":[{\"word\":\"TEST\",\"color\":\"HIDDEN\",\"isGuessed\":false}]}";
+            + ",\"currentClue\":\"Test\",\"remainingGuesses\":1,\"cardList\":[{\"word\":\"TEST\","
+            + "\"color\":\"HIDDEN\",\"isGuessed\":false}]}";
     String result = serializer.serialize(dummyGameState);
     assertEquals(expectedResult, result);
   }
@@ -52,7 +53,7 @@ class SerializationJsonTest {
   }
 
   // Testing exception for writeValueAsString requires passing objectMapper in a constructor.
-  // We then create this custom exception and throw it. (Solution fround on stack overflow)
+  // We then create this custom exception and throw it. (Solution found on stack overflow)
   static class MockJsonProcessingException extends JsonProcessingException {
     public MockJsonProcessingException(String message) {
       super(message);


### PR DESCRIPTION
## Context
This PR contains the extension of the existing chat functionality for Operatives. 

## Description
In the process of creating the functionality for Operatives, it became clear that the current implementation was hard to extend and a simple "extension" would lead to smells such as duplicate code, making future maintainability difficult. The classes in the Chat package were refactored to accommodate an extension for Operatives.

## Changes in the codebase
* Refactoring of chat to promote extension and maintainability in the future
* Introduction of Operative chat
* ChatHistory keeps track of different chats of a lobby
  * Key: "roomKey" (lobby, team, role)
  * Value: List of Chat DTOs
* ChatService keeps track of all ChatHistory objects across all sessions
  * Key: "lobbyID" 
  * Value: ChatHistory object that contains all chat logs
* ChatController now validates if sender is allowed to send their message to their target chat
* LobbyService now has methods to expose the team and role of an individual player

## Changes outside the code base
**N/A**

## Additional information
**N/A**