### PR TITLE
Feature/51 update game state dto

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/playingfield/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/playingfield/GameManager.java
@@ -173,6 +173,7 @@ public class GameManager {
     if (clueValidationService.validateWord(this.board, clue.word())) {
       this.currentClue = clue;
       this.remainingGuesses = clue.guessAmount();
+      advanceTurn();
     } else {
       throw new IllegalArgumentException("Clue is invalid, cannot be a word that is on the board!");
     }

--- a/src/main/java/com/codenames/codenames/backend/playingfield/GameService.java
+++ b/src/main/java/com/codenames/codenames/backend/playingfield/GameService.java
@@ -70,7 +70,6 @@ public class GameService {
   public void submitClue(String lobbyCode, Clue clue, Team callingTeam) {
     GameManager gm = getGame(lobbyCode);
     gm.submitClue(clue, callingTeam);
-    gm.advanceTurn();
   }
 
   /**

--- a/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
@@ -39,7 +39,7 @@ public class DataTransferObjectService {
    * @return a DTO of the current game state
    */
   public GameStateDataTransferObject createGameStateDataTransferObject(
-      GameManager gameManager, Role role, Team currentTurn) {
+      GameManager gameManager, Role role, Team currentTurn, Role currentPhase) {
 
     List<Card> cardList = gameManager.getCardList();
     List<CardDataTransferObject> cardDataTransferObject = new ArrayList<>();
@@ -55,6 +55,7 @@ public class DataTransferObjectService {
     return new GameStateDataTransferObject(
         winner,
         currentTurn,
+        currentPhase,
         gameManager.getCurrentRedFound(),
         gameManager.getCurrentBlueFound(),
         gameManager.getCurrentClueWord(),

--- a/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
@@ -1,5 +1,6 @@
 package com.codenames.codenames.backend.serialization;
 
+import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
 import java.util.List;
 
@@ -17,6 +18,7 @@ import java.util.List;
 public record GameStateDataTransferObject(
     Team winner,
     Team currentTurn,
+    Role currentPhase,
     int currentRedFound,
     int currentBlueFound,
     String currentClue,

--- a/src/test/java/com/codenames/codenames/backend/playingfield/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/playingfield/GameManagerTest.java
@@ -70,7 +70,7 @@ class GameManagerTest {
     return fullListGameManager;
   }
 
-  private void helperMethodAdvanceTurns(int advanceAmount) {
+  private void helperMethodAdvanceTurns(GameManager gameManager, int advanceAmount) {
     for (int i = 0; i < advanceAmount; i++) {
       gameManager.advanceTurn();
     }
@@ -117,7 +117,6 @@ class GameManagerTest {
   void testGetWinner_redStartsRedWins() {
     gameManager = helperMethodGenerateFullCardList(redColor, redTeam);
 
-    helperMethodAdvanceTurns(1);
     for (int i = 0; i < STARTING_TEAM_CARDS; i++) {
       gameManager.flipCard(i, redTeam);
     }
@@ -128,9 +127,8 @@ class GameManagerTest {
   void testGetWinner_redStartsBlueWins() {
     gameManager = helperMethodGenerateFullCardList(blueColor, redTeam);
 
-    helperMethodAdvanceTurns(2); // blue spymaster
+    helperMethodAdvanceTurns(gameManager, 1); // blue spymaster
     helperMethodSubmitClue(gameManager, SECOND_TEAM_CARDS, blueTeam);
-    helperMethodAdvanceTurns(1); // blue operative
 
     for (int i = 0; i < SECOND_TEAM_CARDS; i++) {
       gameManager.flipCard(i, blueTeam);
@@ -141,9 +139,8 @@ class GameManagerTest {
   @Test
   void testGetWinner_blueStartsRedWins() {
     gameManager = helperMethodGenerateFullCardList(redColor, blueTeam);
-    helperMethodAdvanceTurns(2); // red spymaster
+    helperMethodAdvanceTurns(gameManager, 1); // red spymaster
     helperMethodSubmitClue(gameManager, 8, redTeam);
-    helperMethodAdvanceTurns(1); // red operative
 
     for (int i = 0; i < SECOND_TEAM_CARDS; i++) {
       gameManager.flipCard(i, redTeam);
@@ -155,7 +152,6 @@ class GameManagerTest {
   void testGetWinner_blueStartsBlueWins() {
     gameManager = helperMethodGenerateFullCardList(blueColor, blueTeam);
 
-    helperMethodAdvanceTurns(1);
     for (int i = 0; i < STARTING_TEAM_CARDS; i++) {
       gameManager.flipCard(i, blueTeam);
     }
@@ -167,9 +163,8 @@ class GameManagerTest {
     mockCardGeneration(List.of(new Card("Test", Color.BLACK)));
     gameManager = new GameManager(blueTeam, mockCardGenerator, mockClueValidationService);
     helperMethodSubmitClue(gameManager, 1, blueTeam);
-    helperMethodAdvanceTurns(2); // red spymaster
+    helperMethodAdvanceTurns(gameManager, 1); // red spymaster
     helperMethodSubmitClue(gameManager, 1, redTeam);
-    helperMethodAdvanceTurns(1); // red operative
 
     gameManager.flipCard(0, redTeam);
     assertEquals(blueTeam, gameManager.getWinner());
@@ -179,9 +174,8 @@ class GameManagerTest {
   void testGetWinner_blueFoundBlackCardFound() {
     mockCardGeneration(List.of(new Card("Test", Color.BLACK)));
     gameManager = new GameManager(redTeam, mockCardGenerator, mockClueValidationService);
-    helperMethodAdvanceTurns(2); // blue spymaster
+    helperMethodAdvanceTurns(gameManager, 2); // blue spymaster
     helperMethodSubmitClue(gameManager, 1, blueTeam);
-    helperMethodAdvanceTurns(1); // blue operative
     gameManager.flipCard(0, blueTeam);
     assertEquals(redTeam, gameManager.getWinner());
   }
@@ -191,7 +185,6 @@ class GameManagerTest {
     mockCardGeneration(List.of(new Card("Test", Color.WHITE)));
     gameManager = new GameManager(redTeam, mockCardGenerator, mockClueValidationService);
     helperMethodSubmitClue(gameManager, 1, redTeam);
-    helperMethodAdvanceTurns(1);
     gameManager.flipCard(0, redTeam);
     assertNull(gameManager.getWinner());
   }
@@ -199,7 +192,6 @@ class GameManagerTest {
   @Test
   void testFlipCard_cardAlreadyFlipped() {
     helperMethodSubmitClue(gameManager, 1, redTeam);
-    helperMethodAdvanceTurns(1);
     gameManager.flipCard(0, redTeam);
     assertThrows(IllegalStateException.class, () -> gameManager.flipCard(0, redTeam));
   }
@@ -209,7 +201,6 @@ class GameManagerTest {
     mockCardGeneration(List.of(new Card("Test", Color.BLACK)));
     gameManager = new GameManager(blueTeam, mockCardGenerator, mockClueValidationService);
     helperMethodSubmitClue(gameManager, 1, blueTeam);
-    helperMethodAdvanceTurns(1); // red operative
     gameManager.flipCard(0, blueTeam);
     assertThrows(IllegalStateException.class, () -> gameManager.flipCard(0, blueTeam));
   }
@@ -238,7 +229,6 @@ class GameManagerTest {
     mockCardGeneration(List.of(new Card("Test", redColor), new Card("Test2", redColor)));
     gameManager = new GameManager(redTeam, mockCardGenerator, mockClueValidationService);
     helperMethodSubmitClue(gameManager, 0, redTeam);
-    helperMethodAdvanceTurns(1);
     gameManager.flipCard(0, redTeam);
     assertThrows(IllegalStateException.class, () -> gameManager.flipCard(1, redTeam));
   }
@@ -281,44 +271,44 @@ class GameManagerTest {
 
   @Test
   void testAdvanceTurn_spymasterToOperative() {
-    helperMethodAdvanceTurns(1);
+    helperMethodAdvanceTurns(gameManager, 1);
     assertEquals(Role.OPERATIVE, gameManager.getCurrentPhase());
   }
 
   @Test
   void testAdvanceTurn_spymasterToOperative_sameTeam() {
-    helperMethodAdvanceTurns(1);
+    helperMethodAdvanceTurns(gameManager, 1);
     assertEquals(redTeam, gameManager.getCurrentTurn());
   }
 
   @Test
   void testAdvanceTurnTwice_operativeToSpymaster() {
-    helperMethodAdvanceTurns(2);
+    helperMethodAdvanceTurns(gameManager, 2);
     assertEquals(Role.SPYMASTER, gameManager.getCurrentPhase());
   }
 
   @Test
   void testAdvanceTurnTwice_redTeamToBlueTeam() {
-    helperMethodAdvanceTurns(2);
+    helperMethodAdvanceTurns(gameManager, 2);
     assertEquals(blueTeam, gameManager.getCurrentTurn());
   }
 
   @Test
   void testAdvanceTurnTwice_wipeClue() {
-    helperMethodAdvanceTurns(2);
+    helperMethodAdvanceTurns(gameManager, 2);
     assertNull(gameManager.getCurrentClue());
   }
 
   @Test
   void testPassTurn_correctTeam() {
-    helperMethodAdvanceTurns(1);
+    helperMethodAdvanceTurns(gameManager, 1);
     gameManager.passTurn(redTeam);
     assertEquals(blueTeam, gameManager.getCurrentTurn());
   }
 
   @Test
   void testPassTurn_correctPhase() {
-    helperMethodAdvanceTurns(1);
+    helperMethodAdvanceTurns(gameManager, 1);
     gameManager.passTurn(redTeam);
     assertEquals(Role.SPYMASTER, gameManager.getCurrentPhase());
   }

--- a/src/test/java/com/codenames/codenames/backend/playingfield/GameServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/playingfield/GameServiceTest.java
@@ -55,7 +55,6 @@ class GameServiceTest {
 
     gameService.submitClue(lobbyCode, mockClue, redTeam);
     verify(mockGameManager, times(1)).submitClue(mockClue, redTeam);
-    verify(mockGameManager, times(1)).advanceTurn();
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -3,6 +3,7 @@ package com.codenames.codenames.backend.serialization;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.playingfield.Card;
@@ -21,6 +22,8 @@ class DataTransferObjectServiceTest {
   DataTransferObjectService service;
   GameStateDataTransferObject gameStateDto;
   private static final Team redTeam = Team.RED;
+  private static final Role spymaster = Role.SPYMASTER;
+  private static final Role operative = Role.OPERATIVE;
 
   @BeforeEach
   void setUp() {
@@ -36,13 +39,13 @@ class DataTransferObjectServiceTest {
     when(mockGameManager.getCurrentBlueFound()).thenReturn(0);
 
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, Role.OPERATIVE, redTeam);
+        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, spymaster);
   }
 
   @Test
   void testSpymasterVisibility() {
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, Role.SPYMASTER, redTeam);
+        service.createGameStateDataTransferObject(mockGameManager, spymaster, redTeam, spymaster);
     assertEquals("RED", gameStateDto.cardList().get(0).color());
   }
 
@@ -65,7 +68,7 @@ class DataTransferObjectServiceTest {
   void testGetWinner_null() {
     when(mockGameManager.getWinner()).thenReturn(null);
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, Role.OPERATIVE, redTeam);
+        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, spymaster);
     assertNull(gameStateDto.winner());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -68,7 +68,7 @@ class DataTransferObjectServiceTest {
   void testGetWinner_null() {
     when(mockGameManager.getWinner()).thenReturn(null);
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, spymaster);
+        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, operative);
     assertNull(gameStateDto.winner());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -3,7 +3,6 @@ package com.codenames.codenames.backend.serialization;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.playingfield.Card;

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.utility.Color;
+import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +23,8 @@ class SerializationJsonTest {
   List<CardDataTransferObject> dummyList;
   GameStateDataTransferObject dummyGameState;
   ObjectMapper mapper = new ObjectMapper();
+  private static final Team redTeam = Team.RED;
+  private static final Role spymaster = Role.SPYMASTER;
 
   @BeforeEach
   void setUp() {
@@ -30,15 +33,16 @@ class SerializationJsonTest {
 
     dummyList = List.of(new CardDataTransferObject("TEST", "HIDDEN", false));
     dummyGameState =
-        new GameStateDataTransferObject(Team.RED, Team.RED, 0, 0, "Test", 1, dummyList);
+        new GameStateDataTransferObject(redTeam, redTeam, spymaster, 0, 0, "Test", 1, dummyList);
   }
 
   @Test
   void testSerialize_pass() {
     String expectedResult =
-        "{\"winner\":\"RED\",\"currentTurn\":\"RED\",\"currentRedFound\":0,\"currentBlueFound\":0"
-            + ",\"currentClue\":\"Test\",\"remainingGuesses\":1,\"cardList\":[{\"word\":\"TEST\","
-            + "\"color\":\"HIDDEN\",\"isGuessed\":false}]}";
+        "{\"winner\":\"RED\",\"currentTurn\":\"RED\",\"currentPhase\":\"SPYMASTER\","
+            + "\"currentRedFound\":0,\"currentBlueFound\":0,\"currentClue\":\"Test\","
+            + "\"remainingGuesses\":1,\"cardList\":[{\"word\":\"TEST\",\"color\":\"HIDDEN\","
+            + "\"isGuessed\":false}]}";
     String result = serializer.serialize(dummyGameState);
     assertEquals(expectedResult, result);
   }


### PR DESCRIPTION
## Context
This PR contains the addition of the current game phase to the GameStateDTO and some minor fixes.

## Description
To complete the Game Loop in the backend we only need to add the current game phase to the DTO we are sending to the frontend. This way the frontend can display UI changes and the turn management system already acts as a state machine. 

## Changes in the code base
* Addition of current phase to DTO
* Move advance turn out of GameService and back into GameManager for submitClue
* Fix broken tests due to change in code

## Changes outside the code base
**N/A**

## Additional information
**N/A**