### PR TITLE
Clue system fix

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/game/dto/ClueDto.java
+++ b/src/main/java/com/codenames/codenames/backend/game/dto/ClueDto.java
@@ -1,0 +1,12 @@
+package com.codenames.codenames.backend.game.dto;
+
+/**
+ * Data transfer object for a clue, containing the clue word and the allowed number of guesses.
+ * This is only used for sending clues, not for receiving them.
+ * Therefore, the +1 is already included in the guessAmount.
+ *
+ * @param word the hint word
+ * @param guessAmount how many guesses are allowed
+ */
+public record ClueDto(String word, int guessAmount) {
+}

--- a/src/main/java/com/codenames/codenames/backend/playingfield/GameService.java
+++ b/src/main/java/com/codenames/codenames/backend/playingfield/GameService.java
@@ -136,7 +136,9 @@ public class GameService {
    */
   public GameStateDataTransferObject getCurrentGameState(String lobbyCode) {
     GameManager gm = getGame(lobbyCode);
-    return dtoService.createGameStateDataTransferObject(gm, null, gm.getCurrentTurn(), gm.getCurrentPhase());
+    return dtoService.createGameStateDataTransferObject(
+            gm, gm.getCurrentTurn(), gm.getCurrentPhase()
+    );
   }
 
   /**

--- a/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.serialization;
 
 import com.codenames.codenames.backend.clue.Clue;
+import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.playingfield.GameManager;
 import com.codenames.codenames.backend.utility.Color;
@@ -41,11 +42,22 @@ public class DataTransferObjectService {
     for (Card card : cardList) {
       cardDataTransferObject.add(createCardDataTransferObject(card));
     }
+    if (gameManager.getCurrentClue() == null) {
+      return new GameStateDataTransferObject(
+          gameManager.getWinner(),
+          currentTurn,
+          currentPhase,
+          null,
+          cardDataTransferObject);
+    }
+    String word = gameManager.getCurrentClue().word();
+    if(word == null) word = "";
+    int guessAmount = gameManager.getCurrentClue().guessAmount();
     return new GameStateDataTransferObject(
         gameManager.getWinner(),
         currentTurn,
         currentPhase,
-        new Clue(gameManager.getCurrentClue().word(), gameManager.getCurrentClue().guessAmount()),
+        new ClueDto(word, guessAmount),
         cardDataTransferObject);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
@@ -1,6 +1,5 @@
 package com.codenames.codenames.backend.serialization;
 
-import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.playingfield.GameManager;
@@ -30,12 +29,11 @@ public class DataTransferObjectService {
    * Creates the game state DTO that needs to be serialized into JSON.
    *
    * @param gameManager the game manager that holds the state of the game
-   * @param role the role of the player who requires the DTO
    * @param currentTurn the current turn
    * @return a DTO of the current game state
    */
   public GameStateDataTransferObject createGameStateDataTransferObject(
-          GameManager gameManager, Role role, Team currentTurn, Role currentPhase) {
+          GameManager gameManager, Team currentTurn, Role currentPhase) {
 
     List<Card> cardList = gameManager.getCardList();
     List<CardDataTransferObject> cardDataTransferObject = new ArrayList<>();
@@ -51,7 +49,9 @@ public class DataTransferObjectService {
           cardDataTransferObject);
     }
     String word = gameManager.getCurrentClue().word();
-    if(word == null) word = "";
+    if (word == null) {
+      word = "";
+    }
     int guessAmount = gameManager.getCurrentClue().guessAmount();
     return new GameStateDataTransferObject(
         gameManager.getWinner(),

--- a/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
@@ -49,9 +49,6 @@ public class DataTransferObjectService {
           cardDataTransferObject);
     }
     String word = gameManager.getCurrentClue().word();
-    if (word == null) {
-      word = "";
-    }
     int guessAmount = gameManager.getCurrentClue().guessAmount();
     return new GameStateDataTransferObject(
         gameManager.getWinner(),

--- a/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/DataTransferObjectService.java
@@ -1,5 +1,6 @@
 package com.codenames.codenames.backend.serialization;
 
+import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.playingfield.GameManager;
 import com.codenames.codenames.backend.utility.Role;
@@ -56,10 +57,7 @@ public class DataTransferObjectService {
         winner,
         currentTurn,
         currentPhase,
-        gameManager.getCurrentRedFound(),
-        gameManager.getCurrentBlueFound(),
-        gameManager.getCurrentClueWord(),
-        gameManager.getRemainingGuesses(),
+        new Clue(gameManager.getCurrentClue().word(), gameManager.getCurrentClue().guessAmount()),
         cardDataTransferObject);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
@@ -1,6 +1,5 @@
 package com.codenames.codenames.backend.serialization;
 
-import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;

--- a/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
@@ -1,5 +1,6 @@
 package com.codenames.codenames.backend.serialization;
 
+import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
 import java.util.List;
@@ -9,18 +10,12 @@ import java.util.List;
  *
  * @param winner the winner
  * @param currentTurn the current team who is allowed to make a move
- * @param currentRedFound the amount of red cards revealed
- * @param currentBlueFound the amount of red cards revealed
- * @param currentClue the word of the clue
- * @param remainingGuesses the amount of guesses
+ * @param currentClue the current clue object, consisting of word and amount of guesses
  * @param cardList the cards on the board
  */
 public record GameStateDataTransferObject(
     Team winner,
     Team currentTurn,
     Role currentPhase,
-    int currentRedFound,
-    int currentBlueFound,
-    String currentClue,
-    int remainingGuesses,
+    Clue currentClue,
     List<CardDataTransferObject> cardList) {}

--- a/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
+++ b/src/main/java/com/codenames/codenames/backend/serialization/GameStateDataTransferObject.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.serialization;
 
 import com.codenames.codenames.backend.clue.Clue;
+import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.utility.Role;
 import com.codenames.codenames.backend.utility.Team;
 import java.util.List;
@@ -17,5 +18,5 @@ public record GameStateDataTransferObject(
     Team winner,
     Team currentTurn,
     Role currentPhase,
-    Clue currentClue,
+    ClueDto currentClue,
     List<CardDataTransferObject> cardList) {}

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.clue.Clue;
-import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.playingfield.GameManager;
 import com.codenames.codenames.backend.utility.Color;
@@ -40,13 +39,13 @@ class DataTransferObjectServiceTest {
     when(mockGameManager.getCurrentBlueFound()).thenReturn(0);
 
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, spymaster);
+        service.createGameStateDataTransferObject(mockGameManager, redTeam, spymaster);
   }
 
   @Test
   void testSpymasterVisibility() {
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, spymaster, redTeam, spymaster);
+        service.createGameStateDataTransferObject(mockGameManager, redTeam, spymaster);
     assertEquals(Color.RED, gameStateDto.cardList().get(0).color());
   }
 
@@ -69,7 +68,7 @@ class DataTransferObjectServiceTest {
   void testGetWinner_null() {
     when(mockGameManager.getWinner()).thenReturn(null);
     gameStateDto =
-        service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, operative);
+        service.createGameStateDataTransferObject(mockGameManager, redTeam, operative);
     assertNull(gameStateDto.winner());
   }
 
@@ -80,7 +79,7 @@ class DataTransferObjectServiceTest {
     when(mockGameManager.getWinner()).thenReturn(null);
     when(mockGameManager.getCurrentClue()).thenReturn(clue);
 
-    GameStateDataTransferObject dto = service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, operative);
+    GameStateDataTransferObject dto = service.createGameStateDataTransferObject(mockGameManager, redTeam, operative);
 
     assertEquals(clue.word(), dto.currentClue().word());
     assertEquals(clue.guessAmount(), dto.currentClue().guessAmount());

--- a/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/DataTransferObjectServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.clue.Clue;
+import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.playingfield.GameManager;
 import com.codenames.codenames.backend.utility.Color;
@@ -69,5 +71,22 @@ class DataTransferObjectServiceTest {
     gameStateDto =
         service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, operative);
     assertNull(gameStateDto.winner());
+  }
+
+  @Test
+  void testCreateGameStateDataTransferObject() {
+    Clue clue = new Clue("word", 1);
+    when(mockGameManager.getCardList()).thenReturn(List.of());
+    when(mockGameManager.getWinner()).thenReturn(null);
+    when(mockGameManager.getCurrentClue()).thenReturn(clue);
+
+    GameStateDataTransferObject dto = service.createGameStateDataTransferObject(mockGameManager, operative, redTeam, operative);
+
+    assertEquals(clue.word(), dto.currentClue().word());
+    assertEquals(clue.guessAmount(), dto.currentClue().guessAmount());
+    assertNull(dto.winner());
+    assertEquals(0, dto.cardList().size());
+    assertEquals(redTeam, dto.currentTurn());
+    assertEquals(operative, dto.currentPhase());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.utility.Color;
 import com.codenames.codenames.backend.utility.Role;
@@ -33,7 +34,7 @@ class SerializationJsonTest {
 
     dummyList = List.of(new CardDataTransferObject("TEST", "HIDDEN", false));
     dummyGameState =
-        new GameStateDataTransferObject(redTeam, redTeam, spymaster, 0, 0, "Test", 1, dummyList);
+        new GameStateDataTransferObject(redTeam, redTeam, spymaster, new Clue("Test", 1), dummyList);
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.clue.Clue;
+import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.utility.Color;
 import com.codenames.codenames.backend.utility.Role;
@@ -34,16 +35,15 @@ class SerializationJsonTest {
 
     dummyList = List.of(new CardDataTransferObject("TEST", null, false));
     dummyGameState =
-        new GameStateDataTransferObject(redTeam, redTeam, spymaster, new Clue("Test", 1), dummyList);
+        new GameStateDataTransferObject(redTeam, redTeam, spymaster, new ClueDto("Test", 1), dummyList);
   }
 
   @Test
   void testSerialize_pass() {
     String expectedResult =
-        "{\"winner\":\"RED\",\"currentTurn\":\"RED\",\"currentPhase\":\"SPYMASTER\","
-            + "\"currentRedFound\":0,\"currentBlueFound\":0,\"currentClue\":\"Test\","
-            + "\"remainingGuesses\":1,\"cardList\":[{\"word\":\"TEST\",\"color\":null,"
-            + "\"isGuessed\":false}]}";
+            """
+            {"winner":"RED","currentTurn":"RED","currentPhase":"SPYMASTER","currentClue":{"word":"Test","guessAmount":1},"cardList":[{"word":"TEST","color":null,"isGuessed":false}]}"""
+        ;
     String result = serializer.serialize(dummyGameState);
     assertEquals(expectedResult, result);
   }

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.codenames.codenames.backend.clue.Clue;
 import com.codenames.codenames.backend.game.dto.ClueDto;
 import com.codenames.codenames.backend.playingfield.Card;
 import com.codenames.codenames.backend.utility.Color;


### PR DESCRIPTION
# Context
This PR enables clue communication. There were some data type changes necessary to fit the frontend. This should be merged with the corresponding frontend PR to ensure that development works and there are no unexpected behaviours.

# Details
I added a ClueDto, since there were some complication when transferring the clue object to frontend due to the logic in the constructor. Now, the Game State Data Transfer Object contains a ClueDto object, instead of separate remaining guesses and word.

# Changes in the Codebase
- Datatype changes
- new Dto class
- minor changes to tests to fit new needs

# Changes outside the codebase
N/A

# Additional Info
N/A 