### PR TITLE
Feature/130 add db to docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "53213:8080"
     volumes:
       - ./data:/app/data
-    environment:
+    environment:  # Inject datasource url into application.yml when containerized
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/codenames
       SPRING_DATASOURCE_USERNAME: codenames_user
       SPRING_DATASOURCE_PASSWORD: codenames_pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,19 @@
 services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: codenames
+      POSTGRES_USER: codenames_user
+      POSTGRES_PASSWORD: codenames_pass
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U codenames_user -d codenames"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:
     image: ghcr.io/ss26-se2-codenames/backend:latest
     restart: unless-stopped
@@ -6,3 +21,13 @@ services:
       - "53213:8080"
     volumes:
       - ./data:/app/data
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/codenames
+      SPRING_DATASOURCE_USERNAME: codenames_user
+      SPRING_DATASOURCE_PASSWORD: codenames_pass
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,19 @@
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,5 +2,23 @@ spring:
   application:
     name: Codenames_Backend
 
+  datasource:
+    url: jdbc:postgresql://localhost:5432/codenames # When we containerize docker compose will change localhost -> postgresql
+    username: codenames_user
+    password: codenames_pass
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  flyway:
+    enabled: true
+
 app:
   allowed-origins: "http://localhost:8080,http://10.0.2.2:8080"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL # create mock h2 DB in RAM that doesn't close until tests finish
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop      # flyway disabled, hibernate needs to take over and drop tables after test
+  flyway:
+    enabled: false               # H2 might not work with flyway


### PR DESCRIPTION
## Context
This PR adds a PostgreSQL database to the docker compose file. This allows us to deploy the game with a DB in the future.

## Description
* Add postgres 16 to docker
* Add volume for persistent storage even when container lifecycle ends
* Container will now only start when DB is live
* Add H2 database as a temporary solution for future branches while working on DB creation for persistence. We now have a temporary mock DB in memory for every test suit run. 

## Changes in the code base
* pom file now contains new dependencies
* docker compose file updated to include databse
* application.yaml creates a localhost database when we run application in IDE 
  * This is overwritten when we deploy and containerize as docker compose injects the env postgres url into localhost url
* We now have in memory database for tests. 

## Changes outside the code base
**N/A**

## Additional information
**N/A**