### PR TITLE
Feature/131 create jpa tables

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,6 @@
+#Source - https://stackoverflow.com/a/48971823
+#Posted by mladzo, modified by community. See post 'Timeline' for change history
+#Retrieved 2026-06-04, License - CC BY-SA 3.0
+
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/codenames/codenames/backend/database/Card.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Card.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,8 +24,9 @@ public class Card {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @Column(name = "lobby_code", length = 5, nullable = false)
-  private String lobbyCode;
+  @ManyToOne
+  @JoinColumn(name = "lobby_code", nullable = false)
+  private Lobby lobby;
   @Column(nullable = false)
   private int position;
   @Column(length = 11, nullable = false)

--- a/src/main/java/com/codenames/codenames/backend/database/Card.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Card.java
@@ -1,0 +1,32 @@
+package com.codenames.codenames.backend.database;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "card")
+public class Card {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  @Column(name = "lobby_code", length = 5, nullable = false)
+  private String lobbyCode;
+  @Column(nullable = false)
+  private int position;
+  @Column(length = 11, nullable = false)
+  private String word;
+  @Column(length = 8, nullable = false)
+  private String color;
+  @Column(name = "is_guessed", nullable = false)
+  private Boolean isGuessed;
+}

--- a/src/main/java/com/codenames/codenames/backend/database/Card.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Card.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 public class Card {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
+  private Long id;
   @Column(name = "lobby_code", length = 5, nullable = false)
   private String lobbyCode;
   @Column(nullable = false)

--- a/src/main/java/com/codenames/codenames/backend/database/Card.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Card.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persistent entity representing a card record within the database schema.
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -29,7 +29,7 @@ public class GameState {
   @Column(name = "clue_word", length = 20)
   private String clueWord;
   @Column(name = "clue_guess_amount")
-  private long clueGuessAmount;
+  private int clueGuessAmount;
   @Column(name = "remaining_guesses")
-  private long remainingGuesses;
+  private int remainingGuesses;
 }

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persistent entity representing a gameState record within the database schema.
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -20,7 +20,6 @@ import lombok.Setter;
 @Table(name = "game_state")
 public class GameState {
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private String lobbyCode;
   @Column(name = "current_turn", length = 4, nullable = false)
   private String currentTurn;

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,7 +23,12 @@ import lombok.Setter;
 @Table(name = "game_state")
 public class GameState {
   @Id
+  @Column(name = "lobby_code")
   private String lobbyCode;
+  @OneToOne
+  @MapsId
+  @JoinColumn(name = "lobby_code")
+  private Lobby lobby;
   @Column(name = "current_turn", length = 4, nullable = false)
   private String currentTurn;
   @Column(name = "current_phase", length = 9, nullable = false)

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -1,0 +1,32 @@
+package com.codenames.codenames.backend.database;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "game_state")
+public class GameState {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private String lobbyCode;
+  @Column(name = "current_turn", length = 4, nullable = false)
+  private String currentTurn;
+  @Column(name = "current_phase", length = 9, nullable = false)
+  private String currentPhase;
+  @Column(name = "clue_word", length = 20)
+  private String clueWord;
+  @Column(name = "clue_guess_amount")
+  private long clueGuessAmount;
+  @Column(name = "remaining_guesses")
+  private long remainingGuesses;
+}

--- a/src/main/java/com/codenames/codenames/backend/database/GameState.java
+++ b/src/main/java/com/codenames/codenames/backend/database/GameState.java
@@ -2,8 +2,6 @@ package com.codenames.codenames.backend.database;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;

--- a/src/main/java/com/codenames/codenames/backend/database/Lobby.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Lobby.java
@@ -1,0 +1,22 @@
+package com.sample;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "lobby")
+public class Lobby {
+  @Id
+  @Column(name = "lobby_code", length = 5, nullable = false)
+  private String lobbyCode;
+  @Column(name = "created_at", insertable = false, updatable = false, nullable = false)
+  private java.sql.Timestamp createdAt;
+}

--- a/src/main/java/com/codenames/codenames/backend/database/Lobby.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Lobby.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.sql.Timestamp;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,5 +22,5 @@ public class Lobby {
   @Column(name = "lobby_code", length = 5, nullable = false)
   private String lobbyCode;
   @Column(name = "created_at", insertable = false, updatable = false, nullable = false)
-  private java.sql.Timestamp createdAt;
+  private Timestamp createdAt;
 }

--- a/src/main/java/com/codenames/codenames/backend/database/Lobby.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Lobby.java
@@ -1,4 +1,4 @@
-package com.sample;
+package com.codenames.codenames.backend.database;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/codenames/codenames/backend/database/Lobby.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Lobby.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persistent entity representing a lobby record within the database schema.
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/codenames/codenames/backend/database/Lobby.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Lobby.java
@@ -1,10 +1,15 @@
 package com.codenames.codenames.backend.database;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,4 +28,13 @@ public class Lobby {
   private String lobbyCode;
   @Column(name = "created_at", insertable = false, updatable = false, nullable = false)
   private Timestamp createdAt;
+
+  @OneToOne(mappedBy = "lobby", cascade = CascadeType.ALL, orphanRemoval = true)
+  private GameState gameState;
+
+  @OneToMany(mappedBy = "lobby", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Player> players = new ArrayList<>();
+
+  @OneToMany(mappedBy = "lobby", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Card> cards = new ArrayList<>();
 }

--- a/src/main/java/com/codenames/codenames/backend/database/Player.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Player.java
@@ -2,15 +2,11 @@ package com.codenames.codenames.backend.database;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/codenames/codenames/backend/database/Player.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Player.java
@@ -2,9 +2,15 @@ package com.codenames.codenames.backend.database;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,8 +28,9 @@ public class Player {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @Column(name = "lobby_code", length = 5, nullable = false)
-  private String lobbyCode;
+  @ManyToOne
+  @JoinColumn(name = "lobby_code", nullable = false)
+  private Lobby lobby;
   @Column(length = 20, nullable = false)
   private String username;
   @Column(name = "is_host", nullable = false)

--- a/src/main/java/com/codenames/codenames/backend/database/Player.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Player.java
@@ -1,0 +1,32 @@
+package com.codenames.codenames.backend.database;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "player")
+public class Player {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(name = "lobby_code", nullable = false)
+  private String lobbyCode;
+  @Column(nullable = false)
+  private String username;
+  @Column(name = "is_host", nullable = false)
+  private Boolean isHost;
+  @Column(nullable = false)
+  private String team;
+  @Column(nullable = false)
+  private String role;
+}

--- a/src/main/java/com/codenames/codenames/backend/database/Player.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Player.java
@@ -19,14 +19,14 @@ public class Player {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @Column(name = "lobby_code", nullable = false)
+  @Column(name = "lobby_code", length = 5, nullable = false)
   private String lobbyCode;
-  @Column(nullable = false)
+  @Column(length = 20, nullable = false)
   private String username;
   @Column(name = "is_host", nullable = false)
   private Boolean isHost;
-  @Column(nullable = false)
+  @Column(length = 4, nullable = false)
   private String team;
-  @Column(nullable = false)
+  @Column(length = 9, nullable = false)
   private String role;
 }

--- a/src/main/java/com/codenames/codenames/backend/database/Player.java
+++ b/src/main/java/com/codenames/codenames/backend/database/Player.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persistent entity representing a player record within the database schema.
+ */
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
## Context
This PR contains the addition of JPA entity tables that match the DB Schema. 

## Description
The entity classes added now match tables created in the migration script V1. The Lobby Table acts as a main entity, from which all other entities depend on. If an entry is deleted, all other entities are updated.

Rough sketch of the relationships:

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/30b4a9e1-7c06-4d79-a347-8f466571dc67" />


## Changes in the code base
* Addition of Entity classes.

## Changes outside the code base
**N/A**

## Additional information
**N/A**