### PR TITLE
task: added server logs to services

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/game/application/GameService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/GameService.java
@@ -8,6 +8,7 @@ import com.codenames.codenames.backend.game.mapping.DataTransferObjectService;
 import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
  * exposes the methods of the GameManager, so that the websocket controllers can have message
  * mappings to allow frontend to interact with the backend.
  */
+@Slf4j
 @Service
 public class GameService {
 
@@ -41,6 +43,7 @@ public class GameService {
    */
   public void createGameManager(String lobbyCode, Team startingTeam) {
     games.computeIfAbsent(lobbyCode, key -> gameManagerFactory.create(startingTeam));
+    log.info("{}: a new game manager has been created.", lobbyCode);
   }
 
   /**
@@ -50,6 +53,7 @@ public class GameService {
    */
   public void removeGame(String lobbyCode) {
     games.remove(lobbyCode);
+    log.info("{}: Game has been removed from list.", lobbyCode);
   }
 
   /**

--- a/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
@@ -10,9 +10,11 @@ import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /** Service to create the DTO for the game state, which is then serialized into JSON. */
+@Slf4j
 @Service
 public class DataTransferObjectService {
 
@@ -41,6 +43,9 @@ public class DataTransferObjectService {
     List<CardDto> cardDataTransferObject = new ArrayList<>();
     for (Card card : cardList) {
       cardDataTransferObject.add(createCardDto(card));
+    }
+    if (gameManager.getWinner() != null) {
+      log.info("A Game is over. Winner is {}.", gameManager.getWinner());
     }
     if (gameManager.getCurrentClue() == null) {
       return new GameStateDto(

--- a/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStatePersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStatePersistenceService.java
@@ -4,6 +4,7 @@ import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.recovery.domain.snapshot.SystemSnapshot;
 import com.codenames.codenames.backend.recovery.infrastructure.JsonStateStore;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
  * <p>Collects lobby and game snapshots and stores them through the configured {@link
  * JsonStateStore} to enable recovery after application restart.
  */
+@Slf4j
 @Service
 public class SystemStatePersistenceService {
 
@@ -49,5 +51,6 @@ public class SystemStatePersistenceService {
             gameService.getGameSnapshots());
 
     stateStore.save(snapshot);
+    log.info("Saving a new system snapshot.");
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryService.java
+++ b/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryService.java
@@ -60,8 +60,10 @@ public class SystemStateRecoveryService {
               }
               restoreLobbies(snapshot.lobbies());
               restoreGames(snapshot.games());
+              int lobbyCount = (snapshot.lobbies() == null) ? 0 : snapshot.lobbies().size();
+              int gameCount = (snapshot.games() == null) ? 0 : snapshot.games().size();
               log.info("Restoring of {} lobbies and {} games successful.",
-                      snapshot.lobbies().size(), snapshot.games().size()
+                      lobbyCount, gameCount
               );
             });
   }

--- a/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryService.java
+++ b/src/main/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryService.java
@@ -60,6 +60,9 @@ public class SystemStateRecoveryService {
               }
               restoreLobbies(snapshot.lobbies());
               restoreGames(snapshot.games());
+              log.info("Restoring of {} lobbies and {} games successful.",
+                      snapshot.lobbies().size(), snapshot.games().size()
+              );
             });
   }
 
@@ -70,6 +73,7 @@ public class SystemStateRecoveryService {
    */
   private void restoreLobbies(Map<String, List<PlayerDto>> lobbySnapshots) {
     if (lobbySnapshots == null || lobbySnapshots.isEmpty()) {
+      log.info("There were no lobbies to restore.");
       return;
     }
     for (Map.Entry<String, List<PlayerDto>> entry : lobbySnapshots.entrySet()) {
@@ -87,6 +91,7 @@ public class SystemStateRecoveryService {
    */
   private void restoreGames(Map<String, GameStateDto> gameSnapshots) {
     if (gameSnapshots == null || gameSnapshots.isEmpty()) {
+      log.info("There were no games to restore.");
       return;
     }
     for (Map.Entry<String, GameStateDto> entry : gameSnapshots.entrySet()) {
@@ -115,6 +120,7 @@ public class SystemStateRecoveryService {
             .toList();
 
     if (validPlayers.isEmpty()) {
+      log.warn("Skipping restore for lobby {} due to invalid player data.", lobbyCode);
       return null;
     }
 


### PR DESCRIPTION
# Context
For easier debugging and better overview, we were already using Lombok logs during the lobby stage. Now, logs have been added to state persistence services and game services to complete #127.

# Changes in the codebase
Logs have been added to following files: 
- GameService
- SystemStatePersistenceService
- SystemStateRecoveryService
- DataTransferObjectService

# Additional info
Please tell me if I forgot some places where we also might need logs, or add them yourself in the future. Thank you!

# Changes outside the codebase
N/A