### PR TITLE
Feature/133 persistence into database

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/database/entity/LobbyEntity.java
+++ b/src/main/java/com/codenames/codenames/backend/database/entity/LobbyEntity.java
@@ -13,6 +13,8 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SourceType;
 
 /**
  * Persistent entity representing a lobby record within the database schema.
@@ -27,6 +29,7 @@ public class LobbyEntity {
   @Column(name = "lobby_code", length = 5, nullable = false)
   private String lobbyCode;
   @Column(name = "created_at", insertable = false, updatable = false, nullable = false)
+  @CreationTimestamp(source = SourceType.DB)
   private Timestamp createdAt;
 
   @OneToOne(mappedBy = "lobbyEntity", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -6,6 +6,7 @@ import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.domain.Card;
 
+import com.codenames.codenames.backend.game.domain.Clue;
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import java.util.ArrayList;
@@ -71,8 +72,15 @@ public class PersistenceMapper {
     gameStateEntity.setCurrentTurn(gameManager.getCurrentTurn().name());
     gameStateEntity.setCurrentPhase(gameManager.getCurrentPhase().name());
     gameStateEntity.setClueWord(gameManager.getCurrentClueWord());
-    gameStateEntity.setClueGuessAmount(gameStateEntity.getClueGuessAmount());
-    gameStateEntity.setRemainingGuesses(gameStateEntity.getRemainingGuesses());
+
+    Clue currentClue = gameManager.getCurrentClue();
+    if (currentClue != null) {
+      gameStateEntity.setClueGuessAmount(gameManager.getCurrentClue().guessAmount());
+      gameStateEntity.setRemainingGuesses(gameManager.getRemainingGuesses());
+    } else {
+      gameStateEntity.setClueGuessAmount(0);
+      gameStateEntity.setRemainingGuesses(0);
+    }
     return gameStateEntity;
   }
 

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -11,9 +11,22 @@ import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Helper class that is called by the PersistenceService to map all the tables when a snapshot is
+ * created.
+ */
 public class PersistenceMapper {
   // Should be possible to just call save on Lobby object due to cascade. Will find out in the
   // future when this feature/ ticket is finished.
+
+  /**
+   * This method creates and returns a lobby entity that is to be stored into the DB.
+   *
+   * @param lobbyCode the code to act as PK and FK for other tables
+   * @param gameManager the gameManager of an active game to derive information for other tables
+   * @param players the list of players in an active game
+   * @return the lobby entity to be stored into dp
+   */
   public LobbyEntity mapAggregateParentLobbyEntity(
       String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
 
@@ -46,7 +59,6 @@ public class PersistenceMapper {
   }
 
   // Since we are using ORM we always need to map the object as well.
-
 
   private GameStateEntity mapGameState(
       LobbyEntity lobbyEntity, String lobbyCode, GameManager gameManager) {

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -38,14 +38,14 @@ public class PersistenceMapper {
     List<Card> cardList = gameManager.getCardList();
 
     lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
-    lobbyEntity.setCardEntities(mapCard(lobbyEntity, lobbyCode, cardList));
-    lobbyEntity.setPlayerEntities(mapPlayer(lobbyEntity, lobbyCode, players));
+    lobbyEntity.setCardEntities(mapCard(lobbyEntity, cardList));
+    lobbyEntity.setPlayerEntities(mapPlayer(lobbyEntity, players));
 
     return lobbyEntity;
   }
 
   private List<PlayerEntity> mapPlayer(
-      LobbyEntity lobbyEntity, String lobbyCode, List<PlayerDto> players) {
+      LobbyEntity lobbyEntity, List<PlayerDto> players) {
     List<PlayerEntity> playerList = new ArrayList<>();
 
     for (int i = 0; i < players.size(); i++) {
@@ -76,7 +76,7 @@ public class PersistenceMapper {
     return gameStateEntity;
   }
 
-  private List<CardEntity> mapCard(LobbyEntity lobbyEntity, String lobbyCode, List<Card> cards) {
+  private List<CardEntity> mapCard(LobbyEntity lobbyEntity, List<Card> cards) {
     List<CardEntity> cardList = new ArrayList<>();
     for (int i = 0; i < cards.size(); i++) {
       CardEntity cardEntity = new CardEntity();

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -5,7 +5,6 @@ import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.domain.Card;
-
 import com.codenames.codenames.backend.game.domain.Clue;
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -14,24 +14,45 @@ import java.util.List;
 public class PersistenceMapper {
   // Should be possible to just call save on Lobby object due to cascade. Will find out in the
   // future when this feature/ ticket is finished.
-  public LobbyEntity mapLobbyEntity(
+  public LobbyEntity mapAggregateParentLobbyEntity(
       String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
+
     LobbyEntity lobbyEntity = new LobbyEntity();
     lobbyEntity.setLobbyCode(lobbyCode);
 
-    lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
     List<Card> cardList = gameManager.getCardList();
-    lobbyEntity.setCardEntities(mapCard(lobbyEntity, lobbyCode, cardList));
 
+    lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
+    lobbyEntity.setCardEntities(mapCard(lobbyEntity, lobbyCode, cardList));
+    lobbyEntity.setPlayerEntities(mapPlayer(lobbyEntity, lobbyCode, players));
 
     return lobbyEntity;
   }
 
+  private List<PlayerEntity> mapPlayer(
+      LobbyEntity lobbyEntity, String lobbyCode, List<PlayerDto> players) {
+    List<PlayerEntity> playerList = new ArrayList<>();
+
+    for (int i = 0; i < players.size(); i++) {
+      PlayerEntity playerEntity = new PlayerEntity();
+      playerEntity.setLobbyEntity(lobbyEntity);
+      playerEntity.setUsername(players.get(i).username());
+      playerEntity.setIsHost(players.get(i).isHost());
+      playerEntity.setTeam(players.get(i).team().name());
+      playerEntity.setRole(players.get(i).role().name());
+      playerList.add(playerEntity);
+    }
+    return playerList;
+  }
+
+  // Since we are using ORM we always need to map the object as well.
+
+
   private GameStateEntity mapGameState(
       LobbyEntity lobbyEntity, String lobbyCode, GameManager gameManager) {
     GameStateEntity gameStateEntity = new GameStateEntity();
-    // Since we are using ORM we need to map the object as well.
     gameStateEntity.setLobbyEntity(lobbyEntity);
+    // Since we do not have autogenerating PK we need to manually map.
     gameStateEntity.setLobbyCode(lobbyCode);
     gameStateEntity.setCurrentTurn(gameManager.getCurrentTurn().name());
     gameStateEntity.setCurrentPhase(gameManager.getCurrentPhase().name());
@@ -43,7 +64,7 @@ public class PersistenceMapper {
 
   private List<CardEntity> mapCard(LobbyEntity lobbyEntity, String lobbyCode, List<Card> cards) {
     List<CardEntity> cardList = new ArrayList<>();
-    for(int i = 0; i < cards.size(); i++) {
+    for (int i = 0; i < cards.size(); i++) {
       CardEntity cardEntity = new CardEntity();
       cardEntity.setLobbyEntity(lobbyEntity);
       cardEntity.setPosition(i);
@@ -54,6 +75,4 @@ public class PersistenceMapper {
     }
     return cardList;
   }
-
-  private PlayerEntity mapPlayer(List<PlayerDto> players) {}
 }

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -10,11 +10,13 @@ import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
 /**
  * Helper class that is called by the PersistenceService to map all the tables when a snapshot is
  * created.
  */
+@Component
 public class PersistenceMapper {
   // Should be possible to just call save on Lobby object due to cascade. Will find out in the
   // future when this feature/ ticket is finished.

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -8,6 +8,7 @@ import com.codenames.codenames.backend.game.domain.Card;
 
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
+import java.util.ArrayList;
 import java.util.List;
 
 public class PersistenceMapper {
@@ -19,6 +20,9 @@ public class PersistenceMapper {
     lobbyEntity.setLobbyCode(lobbyCode);
 
     lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
+    List<Card> cardList = gameManager.getCardList();
+    lobbyEntity.setCardEntities(mapCard(lobbyEntity, lobbyCode, cardList));
+
 
     return lobbyEntity;
   }
@@ -37,7 +41,19 @@ public class PersistenceMapper {
     return gameStateEntity;
   }
 
-  private CardEntity mapCard(List<Card> cards) {}
+  private List<CardEntity> mapCard(LobbyEntity lobbyEntity, String lobbyCode, List<Card> cards) {
+    List<CardEntity> cardList = new ArrayList<>();
+    for(int i = 0; i < cards.size(); i++) {
+      CardEntity cardEntity = new CardEntity();
+      cardEntity.setLobbyEntity(lobbyEntity);
+      cardEntity.setPosition(i);
+      cardEntity.setWord(cards.get(i).getWord());
+      cardEntity.setColor(cards.get(i).getColor().name());
+      cardEntity.setIsGuessed(cards.get(i).isGuessed());
+      cardList.add(cardEntity);
+    }
+    return cardList;
+  }
 
   private PlayerEntity mapPlayer(List<PlayerDto> players) {}
 }

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -1,10 +1,11 @@
 package com.codenames.codenames.backend.database.persistence;
 
-import com.codenames.codenames.backend.database.Card;
+import com.codenames.codenames.backend.database.entity.CardEntity;
+import com.codenames.codenames.backend.database.entity.GameStateEntity;
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.domain.Card;
-import com.codenames.codenames.backend.database.GameState;
-import com.codenames.codenames.backend.database.Lobby;
-import com.codenames.codenames.backend.database.Player;
+
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import java.util.List;
@@ -12,20 +13,18 @@ import java.util.List;
 public class PersistenceMapper {
   // Should be possible to just call save on Lobby object due to cascade. Will find out in the
   // future when this feature/ ticket is finished.
-  public Lobby mapLobbyEntity(String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
-    Lobby lobby = new Lobby();
+  public LobbyEntity mapLobbyEntity(String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
+    LobbyEntity lobby = new LobbyEntity();
     lobby.setLobbyCode(lobbyCode);
 
     return lobby;
   }
-  private GameState mapGameState(GameState gameState) {
-    return gameState;
+  private GameStateEntity mapGameState(GameManager gameManager) {
   }
 
-  private Card mapCard(List<Card> cards) {
-    return card;
+  private CardEntity mapCard(List<Card> cards) {
   }
-  private Player mapPlayer(List<PlayerDto> players) {
+  private PlayerEntity mapPlayer(List<PlayerDto> players) {
 
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -1,0 +1,31 @@
+package com.codenames.codenames.backend.database.persistence;
+
+import com.codenames.codenames.backend.database.Card;
+import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.database.GameState;
+import com.codenames.codenames.backend.database.Lobby;
+import com.codenames.codenames.backend.database.Player;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
+import java.util.List;
+
+public class PersistenceMapper {
+  // Should be possible to just call save on Lobby object due to cascade. Will find out in the
+  // future when this feature/ ticket is finished.
+  public Lobby mapLobbyEntity(String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
+    Lobby lobby = new Lobby();
+    lobby.setLobbyCode(lobbyCode);
+
+    return lobby;
+  }
+  private GameState mapGameState(GameState gameState) {
+    return gameState;
+  }
+
+  private Card mapCard(List<Card> cards) {
+    return card;
+  }
+  private Player mapPlayer(List<PlayerDto> players) {
+
+  }
+}

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -13,18 +13,31 @@ import java.util.List;
 public class PersistenceMapper {
   // Should be possible to just call save on Lobby object due to cascade. Will find out in the
   // future when this feature/ ticket is finished.
-  public LobbyEntity mapLobbyEntity(String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
-    LobbyEntity lobby = new LobbyEntity();
-    lobby.setLobbyCode(lobbyCode);
+  public LobbyEntity mapLobbyEntity(
+      String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
+    LobbyEntity lobbyEntity = new LobbyEntity();
+    lobbyEntity.setLobbyCode(lobbyCode);
 
-    return lobby;
-  }
-  private GameStateEntity mapGameState(GameManager gameManager) {
+    lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
+
+    return lobbyEntity;
   }
 
-  private CardEntity mapCard(List<Card> cards) {
+  private GameStateEntity mapGameState(
+      LobbyEntity lobbyEntity, String lobbyCode, GameManager gameManager) {
+    GameStateEntity gameStateEntity = new GameStateEntity();
+    // Since we are using ORM we need to map the object as well.
+    gameStateEntity.setLobbyEntity(lobbyEntity);
+    gameStateEntity.setLobbyCode(lobbyCode);
+    gameStateEntity.setCurrentTurn(gameManager.getCurrentTurn().name());
+    gameStateEntity.setCurrentPhase(gameManager.getCurrentPhase().name());
+    gameStateEntity.setClueWord(gameManager.getCurrentClueWord());
+    gameStateEntity.setClueGuessAmount(gameStateEntity.getClueGuessAmount());
+    gameStateEntity.setRemainingGuesses(gameStateEntity.getRemainingGuesses());
+    return gameStateEntity;
   }
-  private PlayerEntity mapPlayer(List<PlayerDto> players) {
 
-  }
+  private CardEntity mapCard(List<Card> cards) {}
+
+  private PlayerEntity mapPlayer(List<PlayerDto> players) {}
 }

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -18,9 +18,6 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class PersistenceMapper {
-  // Should be possible to just call save on Lobby object due to cascade. Will find out in the
-  // future when this feature/ ticket is finished.
-
   /**
    * This method creates and returns a lobby entity that is to be stored into the DB.
    *

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -1,0 +1,42 @@
+package com.codenames.codenames.backend.database.persistence;
+
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
+import com.codenames.codenames.backend.game.application.GameService;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
+import com.codenames.codenames.backend.lobby.application.LobbyService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Service class for storing a snapshot into the database. */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PersistenceService {
+  private final LobbyService lobbyService;
+  private final GameService gameService;
+  private final PersistenceMapper persistenceMapper;
+  private final LobbyRepository lobbyRepository;
+
+  // according to spring docs I might need to configure it somewhere, will check later
+  // default setting is that it triggers rollback on error, should act as transaction from DBMS
+
+  /**
+   * Method to create a snapshot and save it to the database.
+   *
+   * @param lobbyCode the code to identify a lobby
+   */
+  @Transactional
+  public void saveSnapShot(String lobbyCode) {
+    log.info("Saving snapshot of lobby: {}", lobbyCode);
+    GameManager gameManager = gameService.getGameState(lobbyCode);
+    List<PlayerDto> playerList = lobbyService.getPlayersDto(lobbyCode);
+    LobbyEntity lobbySnapShot =
+        persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerList);
+    lobbyRepository.save(lobbySnapShot);
+  }
+}

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -7,7 +7,6 @@ import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,12 +14,27 @@ import org.springframework.transaction.annotation.Transactional;
 /** Service class for storing a snapshot into the database. */
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class PersistenceService {
   private final LobbyService lobbyService;
   private final GameService gameService;
   private final PersistenceMapper persistenceMapper;
   private final LobbyRepository lobbyRepository;
+
+  /**
+   * Constructor for the PersistenceService class.
+   *
+   * @param lobbyService the service class for lobby, from which we derive playerDto
+   * @param gameService the service class for game, from which we derive gameManager
+   * @param persistenceMapper the helper class used for ORM (Object Relational Mapping)
+   * @param lobbyRepository the repository for saving to DB with cascade
+   */
+  public PersistenceService(LobbyService lobbyService, GameService gameService,
+      PersistenceMapper persistenceMapper, LobbyRepository lobbyRepository) {
+    this.lobbyService = lobbyService;
+    this.gameService = gameService;
+    this.persistenceMapper = persistenceMapper;
+    this.lobbyRepository = lobbyRepository;
+  }
 
   // according to spring docs I might need to configure it somewhere, will check later
   // default setting is that it triggers rollback on error, should act as transaction from DBMS

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -36,9 +36,6 @@ public class PersistenceService {
     this.lobbyRepository = lobbyRepository;
   }
 
-  // according to spring docs I might need to configure it somewhere, will check later
-  // default setting is that it triggers rollback on error, should act as transaction from DBMS
-
   /**
    * Method to create a snapshot and save it to the database.
    *

--- a/src/main/java/com/codenames/codenames/backend/database/repository/PlayerRepository.java
+++ b/src/main/java/com/codenames/codenames/backend/database/repository/PlayerRepository.java
@@ -20,5 +20,5 @@ public interface PlayerRepository extends JpaRepository<PlayerEntity, Long> {
    */
   // First Lobby is the Lobby object inside the entity where we can find the lobby_code String.
   // And "resets" the SQL search back to the root table Player
-  Optional<PlayerEntity> findByLobbyLobbyCodeAndUsername(String lobbyCode, String username);
+  Optional<PlayerEntity> findByLobbyEntityLobbyCodeAndUsername(String lobbyCode, String username);
 }

--- a/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
@@ -68,7 +68,6 @@ public class GameSocketController {
   public void revealCard(RevealCardMessage message) {
 
     gameService.flipCard(message.getLobbyCode(), message.getPosition(), message.getCurrentTurn());
-    persistenceService.saveSnapShot(message.getLobbyCode());
 
     messagingTemplate.convertAndSend(
         GAME_TOPIC_PREFIX + message.getLobbyCode(),

--- a/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
@@ -1,12 +1,12 @@
 package com.codenames.codenames.backend.game.api;
 
+import com.codenames.codenames.backend.database.persistence.PersistenceService;
 import com.codenames.codenames.backend.game.api.dto.ClueMessage;
 import com.codenames.codenames.backend.game.api.dto.PassTurnMessage;
 import com.codenames.codenames.backend.game.api.dto.RevealCardMessage;
 import com.codenames.codenames.backend.game.api.dto.StartGameMessage;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.game.domain.Clue;
-import com.codenames.codenames.backend.recovery.application.SystemStatePersistenceService;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
@@ -23,7 +23,7 @@ public class GameSocketController {
   private final GameService gameService;
 
   private final SimpMessagingTemplate messagingTemplate;
-  private final SystemStatePersistenceService persistenceService;
+  private final PersistenceService persistenceService;
 
   private static final String GAME_TOPIC_PREFIX = "/topic/game/";
 
@@ -37,7 +37,7 @@ public class GameSocketController {
   public GameSocketController(
       GameService gameService,
       SimpMessagingTemplate messagingTemplate,
-      SystemStatePersistenceService persistenceService) {
+      PersistenceService persistenceService) {
 
     this.gameService = gameService;
     this.messagingTemplate = messagingTemplate;
@@ -68,7 +68,7 @@ public class GameSocketController {
   public void revealCard(RevealCardMessage message) {
 
     gameService.flipCard(message.getLobbyCode(), message.getPosition(), message.getCurrentTurn());
-    persistenceService.persistCurrentState();
+    persistenceService.saveSnapShot(message.getLobbyCode());
 
     messagingTemplate.convertAndSend(
         GAME_TOPIC_PREFIX + message.getLobbyCode(),
@@ -89,7 +89,7 @@ public class GameSocketController {
         message.getLobbyCode(),
         new Clue(message.getWord(), message.getGuessAmount()),
         message.getCurrentTurn());
-    persistenceService.persistCurrentState();
+    persistenceService.saveSnapShot(message.getLobbyCode());
 
     messagingTemplate.convertAndSend(
         GAME_TOPIC_PREFIX + message.getLobbyCode(),
@@ -105,7 +105,7 @@ public class GameSocketController {
   public void passTurn(PassTurnMessage message) {
 
     gameService.passTurn(message.getLobbyCode(), message.getCurrentTurn());
-    persistenceService.persistCurrentState();
+    persistenceService.saveSnapShot(message.getLobbyCode());
 
     messagingTemplate.convertAndSend(
         GAME_TOPIC_PREFIX + message.getLobbyCode(),

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -63,5 +63,15 @@ class PersistenceMappingTest {
     assertEquals("SPYMASTER", player1.getRole());
   }
 
-  
+  @Test
+  void testMapGameState() {
+    GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
+    assertEquals(lobbyEntity, gameStateEntity.getLobbyEntity());
+    assertEquals(lobbyCode, gameStateEntity.getLobbyCode());
+    assertEquals("RED", gameStateEntity.getCurrentTurn());
+    assertEquals("SPYMASTER", gameStateEntity.getCurrentPhase());
+    assertNull(gameStateEntity.getClueWord());
+    assertEquals(0, gameStateEntity.getClueGuessAmount());
+    assertEquals(0, gameStateEntity.getRemainingGuesses());
+  }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.application.CardGenerator;
 import com.codenames.codenames.backend.game.application.ClueValidationService;
 import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.game.domain.Clue;
 import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
@@ -96,6 +98,20 @@ class PersistenceMappingTest {
     assertNull(gameStateEntity.getClueWord());
     assertEquals(0, gameStateEntity.getClueGuessAmount());
     assertEquals(0, gameStateEntity.getRemainingGuesses());
+  }
+
+  @Test
+  void testMapGameState_notNullClue() {
+    GameManager gameManagerWithClue = helperMethodGenerateFullCardList(redColor, redTeam);
+    when(mockClueValidationService.validateWord(any(), any())).thenReturn(true);
+    gameManager.submitClue(new Clue("TestWord", 1), redTeam);
+    lobbyEntity =
+        persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerDtoList);
+
+    GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
+    assertEquals("TestWord", gameStateEntity.getClueWord());
+    assertEquals(2, gameStateEntity.getClueGuessAmount());
+    assertEquals(2, gameStateEntity.getRemainingGuesses());
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.database.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -14,10 +15,12 @@ import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.application.CardGenerator;
 import com.codenames.codenames.backend.game.application.ClueValidationService;
 import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,8 +28,8 @@ import org.junit.jupiter.api.Test;
 class PersistenceMappingTest {
   private PersistenceMapper persistenceMapper;
   private String lobbyCode;
-  CardGenerator cardGenerator;
-  ClueValidationService clueValidationService;
+  CardGenerator mockCardGenerator;
+  ClueValidationService mockClueValidationService;
   GameManager gameManager;
   PlayerDto player1;
   PlayerDto player2;
@@ -38,10 +41,10 @@ class PersistenceMappingTest {
     persistenceMapper = new PersistenceMapper();
     lobbyCode = "ABCDE";
 
-    cardGenerator = mock(CardGenerator.class);
+    mockCardGenerator = mock(CardGenerator.class);
 
-    clueValidationService = mock(ClueValidationService.class);
-    gameManager = new GameManager(Team.RED, cardGenerator, clueValidationService);
+    mockClueValidationService = mock(ClueValidationService.class);
+    gameManager = new GameManager(Team.RED, mockCardGenerator, mockClueValidationService);
     player1 = new PlayerDto("Test1", Team.RED, Role.SPYMASTER, true);
     player2 = new PlayerDto("Test2", Team.RED, Role.OPERATIVE, false);
     playerDtoList = List.of(player1, player2);
@@ -50,17 +53,34 @@ class PersistenceMappingTest {
         persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerDtoList);
   }
 
+  // Modified helper methods from GameManager to generate a game with full cards
+  private void mockCardGeneration(List<Card> cardList) {
+    when(mockCardGenerator.generateCards(anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+        .thenReturn(cardList);
+  }
+
+  private GameManager helperMethodGenerateFullCardList(Color cardColor, Team startingTeam) {
+    List<Card> cardList = new ArrayList<>();
+    for (int i = 0; i < 25; i++) {
+      cardList.add(new Card("Test" + i, cardColor));
+    }
+    mockCardGeneration(cardList);
+    GameManager fullListGameManager =
+        new GameManager(startingTeam, mockCardGenerator, mockClueValidationService);
+    return fullListGameManager;
+  }
+
   @Test
   void testMapPlayer() {
     List<PlayerEntity> playerEntities = lobbyEntity.getPlayerEntities();
 
-    PlayerEntity player1 = playerEntities.get(0);
+    PlayerEntity retrievedPlayer1 = playerEntities.get(0);
 
-    assertEquals(lobbyEntity, player1.getLobbyEntity());
-    assertEquals("Test1", player1.getUsername());
-    assertTrue(player1.getIsHost());
-    assertEquals("RED", player1.getTeam());
-    assertEquals("SPYMASTER", player1.getRole());
+    assertEquals(lobbyEntity, retrievedPlayer1.getLobbyEntity());
+    assertEquals("Test1", retrievedPlayer1.getUsername());
+    assertTrue(retrievedPlayer1.getIsHost());
+    assertEquals("RED", retrievedPlayer1.getTeam());
+    assertEquals("SPYMASTER", retrievedPlayer1.getRole());
   }
 
   @Test
@@ -73,5 +93,23 @@ class PersistenceMappingTest {
     assertNull(gameStateEntity.getClueWord());
     assertEquals(0, gameStateEntity.getClueGuessAmount());
     assertEquals(0, gameStateEntity.getRemainingGuesses());
+  }
+
+  @Test
+  void testMapCard() {
+    GameManager fullCardGameManager = helperMethodGenerateFullCardList(Color.RED, Team.RED);
+    LobbyEntity fullCardLobbyEntity =
+        persistenceMapper.mapAggregateParentLobbyEntity(
+            lobbyCode, fullCardGameManager, playerDtoList);
+    List<CardEntity> cardEntities = fullCardLobbyEntity.getCardEntities();
+
+    for (int i = 0; i < 25; i++) {
+      CardEntity cardEntity = cardEntities.get(i);
+      assertEquals(fullCardLobbyEntity, cardEntity.getLobbyEntity());
+      assertEquals(i, cardEntity.getPosition());
+      assertEquals("Test" + i, cardEntity.getWord());
+      assertEquals("RED", cardEntity.getColor());
+      assertFalse(cardEntity.getIsGuessed());
+    }
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -35,6 +35,9 @@ class PersistenceMappingTest {
   PlayerDto player2;
   List<PlayerDto> playerDtoList;
   LobbyEntity lobbyEntity;
+  Color redColor = Color.RED;
+  Team redTeam = Team.RED;
+  int maxCardAmount = 25;
 
   @BeforeEach
   void setup() {
@@ -61,13 +64,11 @@ class PersistenceMappingTest {
 
   private GameManager helperMethodGenerateFullCardList(Color cardColor, Team startingTeam) {
     List<Card> cardList = new ArrayList<>();
-    for (int i = 0; i < 25; i++) {
+    for (int i = 0; i < maxCardAmount; i++) {
       cardList.add(new Card("Test" + i, cardColor));
     }
     mockCardGeneration(cardList);
-    GameManager fullListGameManager =
-        new GameManager(startingTeam, mockCardGenerator, mockClueValidationService);
-    return fullListGameManager;
+    return new GameManager(startingTeam, mockCardGenerator, mockClueValidationService);
   }
 
   @Test
@@ -97,13 +98,13 @@ class PersistenceMappingTest {
 
   @Test
   void testMapCard() {
-    GameManager fullCardGameManager = helperMethodGenerateFullCardList(Color.RED, Team.RED);
+    GameManager fullCardGameManager = helperMethodGenerateFullCardList(redColor, redTeam);
     LobbyEntity fullCardLobbyEntity =
         persistenceMapper.mapAggregateParentLobbyEntity(
             lobbyCode, fullCardGameManager, playerDtoList);
     List<CardEntity> cardEntities = fullCardLobbyEntity.getCardEntities();
 
-    for (int i = 0; i < 25; i++) {
+    for (int i = 0; i < maxCardAmount; i++) {
       CardEntity cardEntity = cardEntities.get(i);
       assertEquals(fullCardLobbyEntity, cardEntity.getLobbyEntity());
       assertEquals(i, cardEntity.getPosition());

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -102,7 +102,6 @@ class PersistenceMappingTest {
 
   @Test
   void testMapGameState_notNullClue() {
-    GameManager gameManagerWithClue = helperMethodGenerateFullCardList(redColor, redTeam);
     when(mockClueValidationService.validateWord(any(), any())).thenReturn(true);
     gameManager.submitClue(new Clue("TestWord", 1), redTeam);
     lobbyEntity =

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -1,0 +1,65 @@
+package com.codenames.codenames.backend.database.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codenames.codenames.backend.database.entity.CardEntity;
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.entity.PlayerEntity;
+import com.codenames.codenames.backend.game.application.CardGenerator;
+import com.codenames.codenames.backend.game.application.ClueValidationService;
+import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.game.domain.Color;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
+import com.codenames.codenames.backend.lobby.domain.Role;
+import com.codenames.codenames.backend.lobby.domain.Team;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PersistenceMappingTest {
+  private PersistenceMapper persistenceMapper;
+  private String lobbyCode;
+  CardGenerator cardGenerator;
+  ClueValidationService clueValidationService;
+  GameManager gameManager;
+  PlayerDto player1;
+  PlayerDto player2;
+  List<PlayerDto> playerDtoList;
+  List<Card> dummyCardList;
+
+  @BeforeEach
+  void setup() {
+    persistenceMapper = new PersistenceMapper();
+    lobbyCode = "ABCDE";
+
+    cardGenerator = mock(CardGenerator.class);
+
+    clueValidationService = mock(ClueValidationService.class);
+    gameManager = new GameManager(Team.RED, cardGenerator, clueValidationService);
+    player1 = new PlayerDto("Test1", Team.RED, Role.SPYMASTER, true);
+    player2 = new PlayerDto("Test2", Team.RED, Role.OPERATIVE, false);
+    playerDtoList = List.of(player1, player2);
+  }
+
+  @Test
+  void testMapPlayer() {
+    LobbyEntity lobbyEntity =
+        persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerDtoList);
+    List<PlayerEntity> playerEntities = lobbyEntity.getPlayerEntities();
+
+    PlayerEntity player1 = playerEntities.get(0);
+
+    assertEquals(lobbyEntity, player1.getLobbyEntity());
+    assertEquals("Test1", player1.getUsername());
+    assertTrue(player1.getIsHost());
+    assertEquals("RED", player1.getTeam());
+    assertEquals("SPYMASTER", player1.getRole());
+  }
+
+  
+}

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -28,15 +28,17 @@ import org.junit.jupiter.api.Test;
 class PersistenceMappingTest {
   private PersistenceMapper persistenceMapper;
   private String lobbyCode;
-  CardGenerator mockCardGenerator;
-  ClueValidationService mockClueValidationService;
-  GameManager gameManager;
-  PlayerDto player1;
-  PlayerDto player2;
-  List<PlayerDto> playerDtoList;
-  LobbyEntity lobbyEntity;
-  Color redColor = Color.RED;
-  Team redTeam = Team.RED;
+  private CardGenerator mockCardGenerator;
+  private ClueValidationService mockClueValidationService;
+  private GameManager gameManager;
+  private PlayerDto player1;
+  private PlayerDto player2;
+  private List<PlayerDto> playerDtoList;
+  private LobbyEntity lobbyEntity;
+  private final Color redColor = Color.RED;
+  private final Team redTeam = Team.RED;
+  private final Role spymaster =  Role.SPYMASTER;
+  private final Role operative =  Role.OPERATIVE;
   int maxCardAmount = 25;
 
   @BeforeEach
@@ -47,9 +49,9 @@ class PersistenceMappingTest {
     mockCardGenerator = mock(CardGenerator.class);
 
     mockClueValidationService = mock(ClueValidationService.class);
-    gameManager = new GameManager(Team.RED, mockCardGenerator, mockClueValidationService);
-    player1 = new PlayerDto("Test1", Team.RED, Role.SPYMASTER, true);
-    player2 = new PlayerDto("Test2", Team.RED, Role.OPERATIVE, false);
+    gameManager = new GameManager(redTeam, mockCardGenerator, mockClueValidationService);
+    player1 = new PlayerDto("Test1", redTeam, spymaster, true);
+    player2 = new PlayerDto("Test2", redTeam, operative, false);
     playerDtoList = List.of(player1, player2);
 
     lobbyEntity =

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -1,18 +1,19 @@
 package com.codenames.codenames.backend.database.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.database.entity.CardEntity;
+import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.application.CardGenerator;
 import com.codenames.codenames.backend.game.application.ClueValidationService;
 import com.codenames.codenames.backend.game.domain.Card;
-import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Role;
@@ -30,7 +31,7 @@ class PersistenceMappingTest {
   PlayerDto player1;
   PlayerDto player2;
   List<PlayerDto> playerDtoList;
-  List<Card> dummyCardList;
+  LobbyEntity lobbyEntity;
 
   @BeforeEach
   void setup() {
@@ -44,12 +45,13 @@ class PersistenceMappingTest {
     player1 = new PlayerDto("Test1", Team.RED, Role.SPYMASTER, true);
     player2 = new PlayerDto("Test2", Team.RED, Role.OPERATIVE, false);
     playerDtoList = List.of(player1, player2);
+
+    lobbyEntity =
+        persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerDtoList);
   }
 
   @Test
   void testMapPlayer() {
-    LobbyEntity lobbyEntity =
-        persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerDtoList);
     List<PlayerEntity> playerEntities = lobbyEntity.getPlayerEntities();
 
     PlayerEntity player1 = playerEntities.get(0);

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceMappingTest.java
@@ -39,8 +39,8 @@ class PersistenceMappingTest {
   private LobbyEntity lobbyEntity;
   private final Color redColor = Color.RED;
   private final Team redTeam = Team.RED;
-  private final Role spymaster =  Role.SPYMASTER;
-  private final Role operative =  Role.OPERATIVE;
+  private final Role spymaster = Role.SPYMASTER;
+  private final Role operative = Role.OPERATIVE;
   int maxCardAmount = 25;
 
   @BeforeEach

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -133,13 +133,13 @@ class PersistenceServiceTest {
     List<PlayerEntity> playerList = lobbyEntity.getPlayerEntities();
     assertEquals(2, playerList.size());
 
-    PlayerEntity player1 = playerList.get(0);
+    PlayerEntity playerEntity = playerList.get(0);
 
-    assertEquals(lobbyCode, player1.getLobbyEntity().getLobbyCode());
-    assertEquals("Test1", player1.getUsername());
-    assertTrue(player1.getIsHost());
-    assertEquals("RED", player1.getTeam());
-    assertEquals("SPYMASTER", player1.getRole());
+    assertEquals(lobbyCode, playerEntity.getLobbyEntity().getLobbyCode());
+    assertEquals("Test1", playerEntity.getUsername());
+    assertTrue(playerEntity.getIsHost());
+    assertEquals("RED", playerEntity.getTeam());
+    assertEquals("SPYMASTER", playerEntity.getRole());
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -3,12 +3,14 @@ package com.codenames.codenames.backend.database.persistence;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.database.repository.LobbyRepository;
 import com.codenames.codenames.backend.game.application.CardGenerator;
 import com.codenames.codenames.backend.game.application.ClueValidationService;
@@ -116,6 +118,23 @@ class PersistenceServiceTest {
     assertNull(gameStateEntity.getClueWord());
     assertEquals(0, gameStateEntity.getClueGuessAmount());
     assertEquals(0, gameStateEntity.getRemainingGuesses());
+  }
+
+  @Test
+  void testSaveSnapshot_player() {
+    persistenceService.saveSnapShot(lobbyCode);
+
+    LobbyEntity lobbyEntity = lobbyRepository.findById(lobbyCode).get();
+    List<PlayerEntity> playerList = lobbyEntity.getPlayerEntities();
+    assertEquals(2, playerList.size());
+
+    PlayerEntity player1 = playerList.get(0);
+
+    assertEquals(lobbyCode, player1.getLobbyEntity().getLobbyCode());
+    assertEquals("Test1", player1.getUsername());
+    assertTrue(player1.getIsHost());
+    assertEquals("RED", player1.getTeam());
+    assertEquals("SPYMASTER", player1.getRole());
   }
 
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-
 // (Spring Docs)
 // By default, tests annotated with @DataJpaTest are transactional and roll back at the end of each
 // test.
@@ -70,7 +69,8 @@ class PersistenceServiceTest {
     PersistenceMapper persistenceMapper = new PersistenceMapper();
 
     persistenceService =
-        new PersistenceService(mockLobbyService, mockGameService, persistenceMapper, lobbyRepository);
+        new PersistenceService(
+            mockLobbyService, mockGameService, persistenceMapper, lobbyRepository);
 
     mockCardGenerator = mock(CardGenerator.class);
     mockClueValidationService = mock(ClueValidationService.class);
@@ -153,13 +153,13 @@ class PersistenceServiceTest {
     assertEquals(lobbyCode, cardList.get(0).getLobbyEntity().getLobbyCode());
 
     assertEquals(0, cardList.get(0).getPosition());
-    assertEquals("Test1", cardList.get(0).getWord());
-    assertEquals("RED",  cardList.get(0).getColor());
+    assertEquals("Test0", cardList.get(0).getWord());
+    assertEquals("RED", cardList.get(0).getColor());
     assertFalse(cardList.get(0).getIsGuessed());
 
     assertEquals(24, cardList.get(24).getPosition());
     assertEquals("Test24", cardList.get(24).getWord());
-    assertEquals("RED",  cardList.get(24).getColor());
+    assertEquals("RED", cardList.get(24).getColor());
     assertFalse(cardList.get(24).getIsGuessed());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -103,11 +103,19 @@ class PersistenceServiceTest {
   }
 
   @Test
-  void testSaveSnapshot() {
+  void testSaveSnapshot_gameStateEntity() {
     persistenceService.saveSnapShot(lobbyCode);
 
+    LobbyEntity lobbyEntity = lobbyRepository.findById(lobbyCode).get();
+    GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
+
+    assertNotNull(gameStateEntity);
+    assertEquals(lobbyCode, gameStateEntity.getLobbyCode());
+    assertEquals("RED", gameStateEntity.getCurrentTurn());
+    assertEquals("SPYMASTER", gameStateEntity.getCurrentPhase());
+    assertNull(gameStateEntity.getClueWord());
+    assertEquals(0, gameStateEntity.getClueGuessAmount());
+    assertEquals(0, gameStateEntity.getRemainingGuesses());
   }
-
-
 
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.database.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.database.entity.CardEntity;
 import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.entity.PlayerEntity;
@@ -135,6 +137,31 @@ class PersistenceServiceTest {
     assertTrue(player1.getIsHost());
     assertEquals("RED", player1.getTeam());
     assertEquals("SPYMASTER", player1.getRole());
+  }
+
+  @Test
+  void testSaveSnapshot_card() {
+    persistenceService.saveSnapShot(lobbyCode);
+
+    LobbyEntity lobbyEntity = lobbyRepository.findById(lobbyCode).get();
+    List<CardEntity> cardList = lobbyEntity.getCardEntities();
+
+    assertEquals(25, cardList.size());
+    assertEquals(lobbyCode, cardList.getFirst().getLobbyEntity().getLobbyCode());
+
+    assertEquals(0, cardList.getFirst().getPosition());
+    assertEquals("Test1", cardList.getFirst().getWord());
+    assertEquals("RED",  cardList.getFirst().getColor());
+    assertFalse(cardList.getFirst().getIsGuessed());
+
+    assertEquals(24, cardList.getLast().getPosition());
+    assertEquals("Test24", cardList.getLast().getWord());
+    assertEquals("RED",  cardList.getFirst().getColor());
+    assertFalse(cardList.getLast().getIsGuessed());
+
+
+
+
   }
 
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -105,8 +105,9 @@ class PersistenceServiceTest {
   void testSaveSnapshot_lobbyEntity() {
     persistenceService.saveSnapShot(lobbyCode);
 
-    assertNotNull(lobbyRepository.findById(lobbyCode));
-    assertEquals(lobbyCode, lobbyRepository.findById(lobbyCode).get().getLobbyCode());
+    LobbyEntity lobbyEntity = lobbyRepository.findById(lobbyCode).get();
+    assertNotNull(lobbyEntity);
+    assertEquals(lobbyCode, lobbyEntity.getLobbyCode());
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 
@@ -55,7 +56,9 @@ class PersistenceServiceTest {
   private final Role spymaster = Role.SPYMASTER;
   private final Role operative = Role.OPERATIVE;
 
-  // Cant use new to instantiate Interfaces, Spring will automatically use dependency injection here
+  // Cant use new to instantiate Interfaces --> use @Autowired
+  // Spring checks their active beans (@Repository in this case) and upon matching injects it here
+  @Autowired
   public PersistenceServiceTest(LobbyRepository lobbyRepository) {
     this.lobbyRepository = lobbyRepository;
   }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -1,9 +1,14 @@
 package com.codenames.codenames.backend.database.persistence;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.database.entity.GameStateEntity;
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.repository.LobbyRepository;
 import com.codenames.codenames.backend.game.application.CardGenerator;
 import com.codenames.codenames.backend.game.application.ClueValidationService;
@@ -89,6 +94,13 @@ class PersistenceServiceTest {
     return new GameManager(startingTeam, mockCardGenerator, mockClueValidationService);
   }
 
+  @Test
+  void testSaveSnapshot_lobbyEntity() {
+    persistenceService.saveSnapShot(lobbyCode);
+
+    assertNotNull(lobbyRepository.findById(lobbyCode));
+    assertEquals(lobbyCode, lobbyRepository.findById(lobbyCode).get().getLobbyCode());
+  }
 
   @Test
   void testSaveSnapshot() {

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -147,21 +147,16 @@ class PersistenceServiceTest {
     List<CardEntity> cardList = lobbyEntity.getCardEntities();
 
     assertEquals(25, cardList.size());
-    assertEquals(lobbyCode, cardList.getFirst().getLobbyEntity().getLobbyCode());
+    assertEquals(lobbyCode, cardList.get(0).getLobbyEntity().getLobbyCode());
 
-    assertEquals(0, cardList.getFirst().getPosition());
-    assertEquals("Test1", cardList.getFirst().getWord());
-    assertEquals("RED",  cardList.getFirst().getColor());
-    assertFalse(cardList.getFirst().getIsGuessed());
+    assertEquals(0, cardList.get(0).getPosition());
+    assertEquals("Test1", cardList.get(0).getWord());
+    assertEquals("RED",  cardList.get(0).getColor());
+    assertFalse(cardList.get(0).getIsGuessed());
 
-    assertEquals(24, cardList.getLast().getPosition());
-    assertEquals("Test24", cardList.getLast().getWord());
-    assertEquals("RED",  cardList.getFirst().getColor());
-    assertFalse(cardList.getLast().getIsGuessed());
-
-
-
-
+    assertEquals(24, cardList.get(24).getPosition());
+    assertEquals("Test24", cardList.get(24).getWord());
+    assertEquals("RED",  cardList.get(24).getColor());
+    assertFalse(cardList.get(24).getIsGuessed());
   }
-
 }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -1,0 +1,101 @@
+package com.codenames.codenames.backend.database.persistence;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
+import com.codenames.codenames.backend.game.application.CardGenerator;
+import com.codenames.codenames.backend.game.application.ClueValidationService;
+import com.codenames.codenames.backend.game.application.GameService;
+import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.game.domain.Color;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
+import com.codenames.codenames.backend.lobby.application.LobbyService;
+import com.codenames.codenames.backend.lobby.domain.Role;
+import com.codenames.codenames.backend.lobby.domain.Team;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+
+// (Spring Docs)
+// By default, tests annotated with @DataJpaTest are transactional and roll back at the end of each
+// test.
+// Also, only uses @Entity annotated classes
+@DataJpaTest
+class PersistenceServiceTest {
+  private final LobbyRepository lobbyRepository;
+  private PersistenceService persistenceService;
+  private LobbyService mockLobbyService;
+  private GameService mockGameService;
+  private CardGenerator mockCardGenerator;
+  private ClueValidationService mockClueValidationService;
+  private GameManager gameManager;
+  private List<PlayerDto> playerDtoList;
+  private PlayerDto player1;
+  private PlayerDto player2;
+
+  private final String lobbyCode = "ABCDE";
+  private final int maxCardAmount = 25;
+  private final Color redColor = Color.RED;
+  private final Team redTeam = Team.RED;
+  private final Role spymaster = Role.SPYMASTER;
+  private final Role operative = Role.OPERATIVE;
+
+  // Cant use new to instantiate Interfaces, Spring will automatically use dependency injection here
+  public PersistenceServiceTest(LobbyRepository lobbyRepository) {
+    this.lobbyRepository = lobbyRepository;
+  }
+
+  @BeforeEach
+  void setUp() {
+    mockLobbyService = mock(LobbyService.class);
+    mockGameService = mock(GameService.class);
+    PersistenceMapper persistenceMapper = new PersistenceMapper();
+
+    persistenceService =
+        new PersistenceService(mockLobbyService, mockGameService, persistenceMapper, lobbyRepository);
+
+    mockCardGenerator = mock(CardGenerator.class);
+    mockClueValidationService = mock(ClueValidationService.class);
+
+    gameManager = helperMethodGenerateFullCardList(redColor, redTeam);
+
+    player1 = new PlayerDto("Test1", redTeam, spymaster, true);
+    player2 = new PlayerDto("Test2", redTeam, operative, false);
+
+    playerDtoList = List.of(player1, player2);
+
+    // controlling the saveSnapShot internal methods
+    when(mockGameService.getGameState(lobbyCode)).thenReturn(gameManager);
+    when(mockLobbyService.getPlayersDto(lobbyCode)).thenReturn(playerDtoList);
+  }
+
+  private void mockCardGeneration(List<Card> cardList) {
+    when(mockCardGenerator.generateCards(anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+        .thenReturn(cardList);
+  }
+
+  private GameManager helperMethodGenerateFullCardList(Color cardColor, Team startingTeam) {
+    List<Card> cardList = new ArrayList<>();
+    for (int i = 0; i < maxCardAmount; i++) {
+      cardList.add(new Card("Test" + i, cardColor));
+    }
+    mockCardGeneration(cardList);
+    return new GameManager(startingTeam, mockCardGenerator, mockClueValidationService);
+  }
+
+
+  @Test
+  void testSaveSnapshot() {
+    persistenceService.saveSnapShot(lobbyCode);
+
+  }
+
+
+
+}

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -68,7 +68,6 @@ class GameSocketControllerTest {
     controller.revealCard(message);
 
     verify(gameService).flipCard(LOBBY_CODE, 0, Team.RED);
-    verify(persistenceService).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.codenames.codenames.backend.database.persistence.PersistenceService;
 import com.codenames.codenames.backend.game.api.dto.ClueMessage;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
 import com.codenames.codenames.backend.game.api.dto.PassTurnMessage;
@@ -13,7 +14,6 @@ import com.codenames.codenames.backend.game.api.dto.RevealCardMessage;
 import com.codenames.codenames.backend.game.api.dto.StartGameMessage;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.lobby.domain.Team;
-import com.codenames.codenames.backend.recovery.application.SystemStatePersistenceService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ class GameSocketControllerTest {
 
   @Mock private SimpMessagingTemplate messagingTemplate;
 
-  @Mock private SystemStatePersistenceService persistenceService;
+  @Mock private PersistenceService persistenceService;
 
   private GameSocketController controller;
 
@@ -51,7 +51,7 @@ class GameSocketControllerTest {
 
     controller.startGame(message);
 
-    verify(persistenceService, never()).persistCurrentState();
+    verify(persistenceService, never()).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 
@@ -68,7 +68,7 @@ class GameSocketControllerTest {
     controller.revealCard(message);
 
     verify(gameService).flipCard(LOBBY_CODE, 0, Team.RED);
-    verify(persistenceService).persistCurrentState();
+    verify(persistenceService).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 
@@ -86,7 +86,7 @@ class GameSocketControllerTest {
     controller.submitClue(message);
 
     verify(gameService).submitClue(anyString(), any(), any());
-    verify(persistenceService).persistCurrentState();
+    verify(persistenceService).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 
@@ -102,7 +102,7 @@ class GameSocketControllerTest {
     controller.passTurn(message);
 
     verify(gameService).passTurn(LOBBY_CODE, Team.RED);
-    verify(persistenceService).persistCurrentState();
+    verify(persistenceService).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 


### PR DESCRIPTION
## Context
This PR contains the addition of persistency mapping functionality into our DB.

## Description
The addition of these classes allow us to map the current game state, lobby and player to the entity classes. These will then be stored in the database. 

## Changes in the code base
* Addition of helper mapping class to create snapshot
* Addition of service class for adding snapshot to the DB
* Replace JSON persistence in GameSocketController with DB persistence

## Changes outside the code base
**N/A**

## Additional information
**N/A**