### PR TITLE
Feature/149 server restoration via db

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceMapper.java
@@ -10,12 +10,14 @@ import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
  * Helper class that is called by the PersistenceService to map all the tables when a snapshot is
  * created.
  */
+@Slf4j
 @Component
 public class PersistenceMapper {
   /**
@@ -28,7 +30,6 @@ public class PersistenceMapper {
    */
   public LobbyEntity mapAggregateParentLobbyEntity(
       String lobbyCode, GameManager gameManager, List<PlayerDto> players) {
-
     LobbyEntity lobbyEntity = new LobbyEntity();
     lobbyEntity.setLobbyCode(lobbyCode);
 
@@ -37,7 +38,7 @@ public class PersistenceMapper {
     lobbyEntity.setGameStateEntity(mapGameState(lobbyEntity, lobbyCode, gameManager));
     lobbyEntity.setCardEntities(mapCard(lobbyEntity, cardList));
     lobbyEntity.setPlayerEntities(mapPlayer(lobbyEntity, players));
-
+    log.info("Mapping has been completed");
     return lobbyEntity;
   }
 

--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -49,5 +49,6 @@ public class PersistenceService {
     LobbyEntity lobbySnapShot =
         persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerList);
     lobbyRepository.save(lobbySnapShot);
+    log.info("Snapshot has been saved to DB");
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -3,11 +3,13 @@ package com.codenames.codenames.backend.database.restoration;
 import com.codenames.codenames.backend.database.entity.CardEntity;
 import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
 import com.codenames.codenames.backend.game.domain.Card;
 import com.codenames.codenames.backend.game.domain.Color;
+import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
@@ -24,6 +26,8 @@ public class RestorationMapper {
     return lobby;
   }
 
+  // TODO: I need to create a HashMap with lobbyCode:GameStateDto for this method i want to copy
+  // TODO: from JSON Recovery ```gameService.restoreGameManager(lobbyCode, gameStateManager);```
   private GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
     GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
     if (gameStateEntity == null) {
@@ -56,5 +60,21 @@ public class RestorationMapper {
       cardList.add(cardDto);
     }
     return cardList;
+  }
+
+  private List<PlayerDto> mapToPlayerDto(LobbyEntity lobbyEntity) {
+    List<PlayerDto> playerList = new ArrayList<>();
+
+    for (int i = 0; i < lobbyEntity.getPlayerEntities().size(); i++) {
+      PlayerEntity playerEntity = lobbyEntity.getPlayerEntities().get(i);
+      PlayerDto playerDto =
+          new PlayerDto(
+              playerEntity.getUsername(),
+              Team.valueOf(playerEntity.getTeam()),
+              Role.valueOf(playerEntity.getRole()),
+              playerEntity.getIsHost());
+      playerList.add(playerDto);
+    }
+    return playerList;
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -20,13 +20,12 @@ import org.springframework.stereotype.Component;
 public class RestorationMapper {
 
   public Lobby mapToLobby(LobbyEntity lobbyEntity) {
-    Lobby lobby = new Lobby("", "");
-    GameStateDto gameStateDto = mapToGameStateDto(lobbyEntity);
+    String lobbyCode = lobbyEntity.getLobbyCode();
+    List<PlayerDto> playerDtoList = mapToPlayerDto(lobbyEntity);
+    Lobby lobby = buildLobby(lobbyCode, playerDtoList);
     return lobby;
   }
 
-  // TODO: I need to create a HashMap with lobbyCode:GameStateDto for this method i want to copy
-  // TODO: from JSON Recovery ```gameService.restoreGameManager(lobbyCode, gameStateManager);```
   private GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
     GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
     if (gameStateEntity == null) {

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -7,7 +7,6 @@ import com.codenames.codenames.backend.database.entity.PlayerEntity;
 import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
-import com.codenames.codenames.backend.game.domain.Card;
 import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
@@ -21,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class RestorationMapper {
 
   public Lobby mapToLobby(LobbyEntity lobbyEntity) {
-    Lobby lobby = new Lobby("sd", "d");
+    Lobby lobby = new Lobby("", "");
     GameStateDto gameStateDto = mapToGameStateDto(lobbyEntity);
     return lobby;
   }
@@ -76,5 +75,35 @@ public class RestorationMapper {
       playerList.add(playerDto);
     }
     return playerList;
+  }
+
+  private Lobby buildLobby(String lobbyCode, List<PlayerDto> players) {
+    String hostUsername = findHostUsername(players);
+
+    Lobby lobby = new Lobby(lobbyCode, hostUsername);
+
+    for (PlayerDto player : players) {
+      if (!player.username().equals(hostUsername)) {
+        lobby.addPlayer(player.username(), player.isHost());
+      }
+      if (player.team() != null) {
+        lobby.setPlayerTeam(player.username(), player.team());
+      }
+      if (player.role() != null) {
+        lobby.setPlayerRole(player.username(), player.role());
+      }
+    }
+
+    return lobby;
+  }
+
+  private static String findHostUsername(List<PlayerDto> players) {
+    String hostUsername = "";
+    for (PlayerDto playerDto : players) {
+      if (playerDto.isHost()){
+        hostUsername = playerDto.username();
+      }
+    }
+    return hostUsername;
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -8,7 +8,6 @@ import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
 import com.codenames.codenames.backend.game.domain.Color;
-import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import com.codenames.codenames.backend.lobby.domain.Role;
@@ -17,20 +16,34 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
+/**
+ * Helper class responsible for creating Lobby and GameStateDto, used by RestorationService.
+ */
 @Component
 public class RestorationMapper {
 
+  /**
+   * Exposed method to generate a Lobby object.
+   *
+   * @param lobbyEntity the lobby entry from the database
+   * @return a Lobby object to be used by RestorationService
+   */
   public Lobby mapToLobby(LobbyEntity lobbyEntity) {
     String lobbyCode = lobbyEntity.getLobbyCode();
     List<PlayerDto> playerDtoList = mapToPlayerDto(lobbyEntity);
-    Lobby lobby = buildLobby(lobbyCode, playerDtoList);
-    return lobby;
+    return buildLobby(lobbyCode, playerDtoList);
   }
 
+  /**
+   * Exposed method to generate a GameStateDto object.
+   *
+   * @param lobbyEntity the lobby entry from the database
+   * @return a Lobby object to be used by RestorationService
+   */
   public GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
     GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
     if (gameStateEntity == null) {
-      throw new RuntimeException("Game state entity is null");
+      throw new IllegalStateException("Game state entity is null");
     }
 
     Team winner = null;
@@ -99,7 +112,7 @@ public class RestorationMapper {
   private static String findHostUsername(List<PlayerDto> players) {
     String hostUsername = "";
     for (PlayerDto playerDto : players) {
-      if (playerDto.isHost()){
+      if (playerDto.isHost()) {
         hostUsername = playerDto.username();
       }
     }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -1,11 +1,13 @@
 package com.codenames.codenames.backend.database.restoration;
 
+import com.codenames.codenames.backend.database.entity.CardEntity;
 import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
 import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
@@ -33,16 +35,26 @@ public class RestorationMapper {
     Team currentTeam = Team.valueOf(gameStateEntity.getCurrentTurn());
     Role currentPhase = Role.valueOf(gameStateEntity.getCurrentPhase());
     ClueDto clueDto = null;
-    if(gameStateEntity.getClueWord() != null) {
+    if (gameStateEntity.getClueWord() != null) {
       clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
     }
-    List<CardDto> cardList = new ArrayList<>(25);
-
+    List<CardDto> cardList = mapToCardDto(lobbyEntity);
+    mapToCardDto(lobbyEntity);
     return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList);
-
   }
 
   private List<CardDto> mapToCardDto(LobbyEntity lobbyEntity) {
+    List<CardDto> cardList = new ArrayList<>(25);
 
+    for (int i = 0; i < 25; i++) {
+      CardEntity currentCardEntity = lobbyEntity.getCardEntities().get(i);
+      CardDto cardDto =
+          new CardDto(
+              currentCardEntity.getWord(),
+              Color.valueOf(currentCardEntity.getColor()),
+              currentCardEntity.getIsGuessed());
+      cardList.add(cardDto);
+    }
+    return cardList;
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -1,0 +1,48 @@
+package com.codenames.codenames.backend.database.restoration;
+
+import com.codenames.codenames.backend.database.entity.GameStateEntity;
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.game.api.dto.CardDto;
+import com.codenames.codenames.backend.game.api.dto.ClueDto;
+import com.codenames.codenames.backend.game.api.dto.GameStateDto;
+import com.codenames.codenames.backend.game.domain.Card;
+import com.codenames.codenames.backend.lobby.domain.Lobby;
+import com.codenames.codenames.backend.lobby.domain.Role;
+import com.codenames.codenames.backend.lobby.domain.Team;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestorationMapper {
+
+  public Lobby mapToLobby(LobbyEntity lobbyEntity) {
+    Lobby lobby = new Lobby("sd", "d");
+    GameStateDto gameStateDto = mapToGameStateDto(lobbyEntity);
+    return lobby;
+  }
+
+  private GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
+    GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
+    if (gameStateEntity == null) {
+      throw new RuntimeException("Game state entity is null");
+    }
+
+    Team winner = null;
+    // valueOf takes string and returns enum of that string
+    Team currentTeam = Team.valueOf(gameStateEntity.getCurrentTurn());
+    Role currentPhase = Role.valueOf(gameStateEntity.getCurrentPhase());
+    ClueDto clueDto = null;
+    if(gameStateEntity.getClueWord() != null) {
+      clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
+    }
+    List<CardDto> cardList = new ArrayList<>(25);
+
+    return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList);
+
+  }
+
+  private List<CardDto> mapToCardDto(LobbyEntity lobbyEntity) {
+
+  }
+}

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -42,7 +42,6 @@ public class RestorationMapper {
       clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
     }
     List<CardDto> cardList = mapToCardDto(lobbyEntity);
-    mapToCardDto(lobbyEntity);
     return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList);
   }
 

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -61,8 +61,7 @@ public class RestorationMapper {
   private List<CardDto> mapToCardDto(LobbyEntity lobbyEntity) {
     List<CardDto> cardList = new ArrayList<>(25);
 
-    for (int i = 0; i < 25; i++) {
-      CardEntity currentCardEntity = lobbyEntity.getCardEntities().get(i);
+    for (CardEntity currentCardEntity : lobbyEntity.getCardEntities()) {
       CardDto cardDto =
           new CardDto(
               currentCardEntity.getWord(),

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -8,6 +8,7 @@ import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
 import com.codenames.codenames.backend.game.domain.Color;
+import com.codenames.codenames.backend.game.domain.GameManager;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import com.codenames.codenames.backend.lobby.domain.Role;
@@ -26,7 +27,7 @@ public class RestorationMapper {
     return lobby;
   }
 
-  private GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
+  public GameStateDto mapToGameStateDto(LobbyEntity lobbyEntity) {
     GameStateEntity gameStateEntity = lobbyEntity.getGameStateEntity();
     if (gameStateEntity == null) {
       throw new RuntimeException("Game state entity is null");

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -77,11 +77,19 @@ public class RestorationMapper {
 
     for (int i = 0; i < lobbyEntity.getPlayerEntities().size(); i++) {
       PlayerEntity playerEntity = lobbyEntity.getPlayerEntities().get(i);
+      Team team = null;
+      if (playerEntity.getTeam() != null) {
+        team = Team.valueOf(playerEntity.getTeam());
+      }
+      Role role = null;
+      if (playerEntity.getRole() != null) {
+        role = Role.valueOf(playerEntity.getRole());
+      }
       PlayerDto playerDto =
           new PlayerDto(
               playerEntity.getUsername(),
-              Team.valueOf(playerEntity.getTeam()),
-              Role.valueOf(playerEntity.getRole()),
+              team,
+              role,
               playerEntity.getIsHost());
       playerList.add(playerDto);
     }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
@@ -9,9 +9,11 @@ import com.codenames.codenames.backend.game.domain.GameManagerFactory;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import jakarta.annotation.PostConstruct;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional(readOnly = true)
 public class RestorationService {
   private final RestorationMapper restorationMapper;
   private final LobbyRepository lobbyRepository;

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
@@ -10,13 +10,13 @@ import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 
-/**
- * Service class responsible for re-creating all lobbies and game managers.
- */
+/** Service class responsible for re-creating all lobbies and game managers. */
 @Service
-@Transactional(readOnly = true)
 public class RestorationService {
   private final RestorationMapper restorationMapper;
   private final LobbyRepository lobbyRepository;
@@ -24,6 +24,8 @@ public class RestorationService {
   private final LobbyService lobbyService;
   private final GameService gameService;
   private final GameManagerFactory gameManagerFactory;
+
+  private final PlatformTransactionManager transactionManager;
 
   /**
    * Constructor for the service class.
@@ -34,30 +36,46 @@ public class RestorationService {
    * @param gameService service class responsible for binding a gameManager to a lobby
    * @param gameManagerFactory factory class responsible for creating a gameManager
    */
-  public RestorationService(RestorationMapper restorationMapper, LobbyRepository lobbyRepository,
-      LobbyService lobbyService, GameService gameService, GameManagerFactory gameManagerFactory) {
+  public RestorationService(
+      RestorationMapper restorationMapper,
+      LobbyRepository lobbyRepository,
+      LobbyService lobbyService,
+      GameService gameService,
+      GameManagerFactory gameManagerFactory,
+      PlatformTransactionManager transactionManager) {
     this.restorationMapper = restorationMapper;
     this.lobbyRepository = lobbyRepository;
     this.lobbyService = lobbyService;
     this.gameService = gameService;
     this.gameManagerFactory = gameManagerFactory;
+    this.transactionManager = transactionManager;
   }
 
-  /**
-   * Using PostConstruct we automatically call this method when the container restarts.
-   */
+  /** Using PostConstruct we automatically call this method when the container restarts. */
   // @PostConstruct methods technically gets called right after the beans are initialized
+  // Turns out you cannot have PostConstruct and Transactional annotation together
+  // Solution is to use Transaction Template --> Solution found on StackOverflow
   @PostConstruct
   public void restoreOnContainerStart() {
-    for (LobbyEntity lobbyEntity : lobbyRepository.findAll()) {
-      String lobbyCode = lobbyEntity.getLobbyCode();
 
-      Lobby lobbyObj = restorationMapper.mapToLobby(lobbyEntity);
-      lobbyService.restoreLobby(lobbyCode, lobbyObj);
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    transactionTemplate.setReadOnly(true);
 
-      GameStateDto gameStateDtoObj = restorationMapper.mapToGameStateDto(lobbyEntity);
-      GameManager gameManagerObj = gameManagerFactory.createFromSnapshot(gameStateDtoObj);
-      gameService.restoreGameManager(lobbyCode, gameManagerObj);
-    }
+    transactionTemplate.execute(
+        new TransactionCallbackWithoutResult() {
+          @Override
+          protected void doInTransactionWithoutResult(TransactionStatus status) {
+            for (LobbyEntity lobbyEntity : lobbyRepository.findAll()) {
+              String lobbyCode = lobbyEntity.getLobbyCode();
+
+              Lobby lobbyObj = restorationMapper.mapToLobby(lobbyEntity);
+              lobbyService.restoreLobby(lobbyCode, lobbyObj);
+
+              GameStateDto gameStateDtoObj = restorationMapper.mapToGameStateDto(lobbyEntity);
+              GameManager gameManagerObj = gameManagerFactory.createFromSnapshot(gameStateDtoObj);
+              gameService.restoreGameManager(lobbyCode, gameManagerObj);
+            }
+          }
+        });
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
@@ -1,0 +1,45 @@
+package com.codenames.codenames.backend.database.restoration;
+
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
+import com.codenames.codenames.backend.game.api.dto.GameStateDto;
+import com.codenames.codenames.backend.game.application.GameService;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.game.domain.GameManagerFactory;
+import com.codenames.codenames.backend.lobby.application.LobbyService;
+import com.codenames.codenames.backend.lobby.domain.Lobby;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RestorationService {
+  private final RestorationMapper restorationMapper;
+  private final LobbyRepository lobbyRepository;
+
+  private final LobbyService lobbyService;
+  private final GameService gameService;
+  private final GameManagerFactory gameManagerFactory;
+
+  public RestorationService(RestorationMapper restorationMapper, LobbyRepository lobbyRepository,
+      LobbyService lobbyService, GameService gameService, GameManagerFactory gameManagerFactory) {
+    this.restorationMapper = restorationMapper;
+    this.lobbyRepository = lobbyRepository;
+    this.lobbyService = lobbyService;
+    this.gameService = gameService;
+    this.gameManagerFactory = gameManagerFactory;
+  }
+
+  @PostConstruct
+  public void restoreOnContainerStart() {
+    for (LobbyEntity lobbyEntity : lobbyRepository.findAll()) {
+      String lobbyCode = lobbyEntity.getLobbyCode();
+
+      Lobby lobbyObj = restorationMapper.mapToLobby(lobbyEntity);
+      lobbyService.restoreLobby(lobbyCode, lobbyObj);
+
+      GameStateDto gameStateDtoObj = restorationMapper.mapToGameStateDto(lobbyEntity);
+      GameManager gameManagerObj = gameManagerFactory.createFromSnapshot(gameStateDtoObj);
+      gameService.restoreGameManager(lobbyCode, gameManagerObj);
+    }
+  }
+}

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
@@ -9,6 +9,7 @@ import com.codenames.codenames.backend.game.domain.GameManagerFactory;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -16,6 +17,7 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /** Service class responsible for re-creating all lobbies and game managers. */
+@Slf4j
 @Service
 public class RestorationService {
   private final RestorationMapper restorationMapper;
@@ -69,11 +71,15 @@ public class RestorationService {
               String lobbyCode = lobbyEntity.getLobbyCode();
 
               Lobby lobbyObj = restorationMapper.mapToLobby(lobbyEntity);
+              log.info("Attempting to restore lobby: {}", lobbyCode);
               lobbyService.restoreLobby(lobbyCode, lobbyObj);
+              log.info("Lobby has been restored: {}", lobbyCode);
 
               GameStateDto gameStateDtoObj = restorationMapper.mapToGameStateDto(lobbyEntity);
               GameManager gameManagerObj = gameManagerFactory.createFromSnapshot(gameStateDtoObj);
+              log.info("Attempting to restore game: {}", lobbyCode);
               gameService.restoreGameManager(lobbyCode, gameManagerObj);
+              log.info("Game  has been restored: {}", lobbyCode);
             }
           }
         });

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationService.java
@@ -9,9 +9,12 @@ import com.codenames.codenames.backend.game.domain.GameManagerFactory;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
 import jakarta.annotation.PostConstruct;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Service class responsible for re-creating all lobbies and game managers.
+ */
 @Service
 @Transactional(readOnly = true)
 public class RestorationService {
@@ -22,6 +25,15 @@ public class RestorationService {
   private final GameService gameService;
   private final GameManagerFactory gameManagerFactory;
 
+  /**
+   * Constructor for the service class.
+   *
+   * @param restorationMapper the helper class used to create Lobby and GameStateDto
+   * @param lobbyRepository the lobby entry from the database
+   * @param lobbyService service class responsible for adding a lobby to a list of active lobbies
+   * @param gameService service class responsible for binding a gameManager to a lobby
+   * @param gameManagerFactory factory class responsible for creating a gameManager
+   */
   public RestorationService(RestorationMapper restorationMapper, LobbyRepository lobbyRepository,
       LobbyService lobbyService, GameService gameService, GameManagerFactory gameManagerFactory) {
     this.restorationMapper = restorationMapper;
@@ -31,6 +43,10 @@ public class RestorationService {
     this.gameManagerFactory = gameManagerFactory;
   }
 
+  /**
+   * Using PostConstruct we automatically call this method when the container restarts.
+   */
+  // @PostConstruct methods technically gets called right after the beans are initialized
   @PostConstruct
   public void restoreOnContainerStart() {
     for (LobbyEntity lobbyEntity : lobbyRepository.findAll()) {

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -98,5 +98,28 @@ class RestorationMapperTest {
     assertNull(gameStateDto.currentClue());
   }
 
+  @Test
+  void testBuildLobby_nullTeam() {
+    PlayerEntity playerEntity = new PlayerEntity();
+    playerEntity.setLobbyEntity(lobbyEntity);
+    playerEntity.setUsername("TestPlayer");
+    playerEntity.setIsHost(true);
+    playerEntity.setTeam(redTeam.toString());
+    playerEntity.setRole(operativeRole.toString());
+
+    PlayerEntity playerEntity2 = new PlayerEntity();
+    playerEntity2.setLobbyEntity(lobbyEntity);
+    playerEntity2.setUsername("TestPlayer2");
+    playerEntity2.setIsHost(false);
+    playerEntity2.setTeam(null);
+    playerEntity2.setRole(operativeRole.toString());
+    List<PlayerEntity> playerList = List.of(playerEntity, playerEntity2);
+
+    lobbyEntity.setPlayerEntities(playerList);
+
+    Lobby lobby = restorationMapper.mapToLobby(lobbyEntity);
+
+    assertNull(lobby.getPlayerTeam("TestPlayer2"));
+  }
 
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -80,7 +80,6 @@ class RestorationMapperTest {
 
   @Test
   void testMapToGameDto_null() {
-    when(lobbyEntity.getGameStateEntity()).thenReturn(null);
     assertThrows(
         IllegalStateException.class, () -> restorationMapper.mapToGameStateDto(lobbyEntity));
   }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.database.entity.CardEntity;
 import com.codenames.codenames.backend.database.entity.GameStateEntity;

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -80,9 +80,22 @@ class RestorationMapperTest {
 
   @Test
   void testMapToGameDto_null() {
-    when(lobbyEntity.getCardEntities()).thenReturn(null);
+    when(lobbyEntity.getGameStateEntity()).thenReturn(null);
     assertThrows(
         IllegalStateException.class, () -> restorationMapper.mapToGameStateDto(lobbyEntity));
+  }
+
+  @Test
+  void testMapToGameDto_nullClueWord() {
+    GameStateEntity gameStateEntity = new GameStateEntity();
+    gameStateEntity.setCurrentTurn("RED");
+    gameStateEntity.setCurrentPhase("OPERATIVE");
+    gameStateEntity.setClueWord(null);
+    gameStateEntity.setClueGuessAmount(3);
+    lobbyEntity.setGameStateEntity(gameStateEntity);
+
+    GameStateDto gameStateDto = restorationMapper.mapToGameStateDto(lobbyEntity);
+    assertNull(gameStateDto.currentClue());
   }
 
 

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -1,0 +1,46 @@
+package com.codenames.codenames.backend.database.restoration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.codenames.codenames.backend.database.entity.CardEntity;
+import com.codenames.codenames.backend.database.entity.GameStateEntity;
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.entity.PlayerEntity;
+import com.codenames.codenames.backend.lobby.domain.Lobby;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RestorationMapperTest {
+  private RestorationMapper restorationMapper;
+  private LobbyEntity lobbyEntity;
+
+  @BeforeEach
+  void setUp() {
+    restorationMapper = new RestorationMapper();
+    lobbyEntity = new LobbyEntity();
+    lobbyEntity.setLobbyCode("ABCDE");
+  }
+
+  @Test
+  void testMapToLobbyDto() {
+    PlayerEntity playerEntity = new PlayerEntity();
+    playerEntity.setLobbyEntity(lobbyEntity);
+    playerEntity.setUsername("Player1");
+    playerEntity.setIsHost(true);
+    playerEntity.setTeam("RED");
+    playerEntity.setRole("OPERATIVE");
+    List<PlayerEntity> playerList = List.of(playerEntity);
+    lobbyEntity.setPlayerEntities(playerList);
+
+    Lobby lobby = restorationMapper.mapToLobby(lobbyEntity);
+
+    assertNotNull(lobby);
+    assertEquals("ABCDE", lobby.getLobbyCode());
+
+    assertEquals(1, lobby.getPlayerList().size());
+  }
+
+  
+}

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -77,4 +77,13 @@ class RestorationMapperTest {
     assertEquals("TestCardWord", gameStateDto.cardList().get(0).word());
     assertEquals(redColor, gameStateDto.cardList().get(0).color());
   }
+
+  @Test
+  void testMapToGameDto_null() {
+    when(lobbyEntity.getCardEntities()).thenReturn(null);
+    assertThrows(
+        IllegalStateException.class, () -> restorationMapper.mapToGameStateDto(lobbyEntity));
+  }
+
+
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -2,12 +2,19 @@ package com.codenames.codenames.backend.database.restoration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.database.entity.CardEntity;
 import com.codenames.codenames.backend.database.entity.GameStateEntity;
 import com.codenames.codenames.backend.database.entity.LobbyEntity;
 import com.codenames.codenames.backend.database.entity.PlayerEntity;
+import com.codenames.codenames.backend.game.api.dto.GameStateDto;
+import com.codenames.codenames.backend.game.domain.Color;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
+import com.codenames.codenames.backend.lobby.domain.Role;
+import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,6 +22,9 @@ import org.junit.jupiter.api.Test;
 class RestorationMapperTest {
   private RestorationMapper restorationMapper;
   private LobbyEntity lobbyEntity;
+  private final Team redTeam = Team.RED;
+  private final Color redColor = Color.RED;
+  private final Role operativeRole = Role.OPERATIVE;
 
   @BeforeEach
   void setUp() {
@@ -42,5 +52,29 @@ class RestorationMapperTest {
     assertEquals(1, lobby.getPlayerList().size());
   }
 
-  
+  @Test
+  void testMapToGameDto() {
+    GameStateEntity gameStateEntity = new GameStateEntity();
+    gameStateEntity.setCurrentTurn("RED");
+    gameStateEntity.setCurrentPhase("OPERATIVE");
+    gameStateEntity.setClueWord("TestClueWord");
+    gameStateEntity.setClueGuessAmount(3);
+    lobbyEntity.setGameStateEntity(gameStateEntity);
+
+    CardEntity card = new CardEntity();
+    card.setWord("TestCardWord");
+    card.setColor("RED");
+    card.setIsGuessed(false);
+    lobbyEntity.setCardEntities(List.of(card));
+
+    GameStateDto gameStateDto = restorationMapper.mapToGameStateDto(lobbyEntity);
+
+    assertNotNull(gameStateDto);
+    assertEquals(redTeam, gameStateDto.currentTurn());
+    assertEquals(operativeRole, gameStateDto.currentPhase());
+    assertEquals("TestClueWord", gameStateDto.currentClue().word());
+    assertEquals(1, gameStateDto.cardList().size());
+    assertEquals("TestCardWord", gameStateDto.cardList().get(0).word());
+    assertEquals(redColor, gameStateDto.cardList().get(0).color());
+  }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationMapperTest.java
@@ -122,4 +122,28 @@ class RestorationMapperTest {
     assertNull(lobby.getPlayerTeam("TestPlayer2"));
   }
 
+  @Test
+  void testBuildLobby_nullRole() {
+    PlayerEntity playerEntity = new PlayerEntity();
+    playerEntity.setLobbyEntity(lobbyEntity);
+    playerEntity.setUsername("TestPlayer");
+    playerEntity.setIsHost(true);
+    playerEntity.setTeam(redTeam.toString());
+    playerEntity.setRole(operativeRole.toString());
+
+    PlayerEntity playerEntity2 = new PlayerEntity();
+    playerEntity2.setLobbyEntity(lobbyEntity);
+    playerEntity2.setUsername("TestPlayer2");
+    playerEntity2.setIsHost(false);
+    playerEntity2.setTeam(redTeam.toString());
+    playerEntity2.setRole(null);
+    List<PlayerEntity> playerList = List.of(playerEntity, playerEntity2);
+
+    lobbyEntity.setPlayerEntities(playerList);
+
+    Lobby lobby = restorationMapper.mapToLobby(lobbyEntity);
+
+    assertNull(lobby.getPlayerRole("TestPlayer2"));
+  }
+
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
@@ -1,0 +1,89 @@
+package com.codenames.codenames.backend.database.restoration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codenames.codenames.backend.database.entity.LobbyEntity;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
+import com.codenames.codenames.backend.game.api.dto.CardDto;
+import com.codenames.codenames.backend.game.api.dto.ClueDto;
+import com.codenames.codenames.backend.game.api.dto.GameStateDto;
+import com.codenames.codenames.backend.game.application.GameService;
+import com.codenames.codenames.backend.game.domain.GameManager;
+import com.codenames.codenames.backend.game.domain.GameManagerFactory;
+import com.codenames.codenames.backend.lobby.application.LobbyService;
+import com.codenames.codenames.backend.lobby.domain.Lobby;
+import com.codenames.codenames.backend.lobby.domain.Role;
+import com.codenames.codenames.backend.lobby.domain.Team;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+
+class RestorationServiceTest {
+  private RestorationService restorationService;
+  private RestorationMapper restorationMapper;
+  private GameManagerFactory gameManagerFactory;
+  private LobbyService lobbyService;
+  private LobbyRepository lobbyRepository;
+  private GameService gameService;
+  private TransactionStatus transactionStatus;
+  private PlatformTransactionManager transactionManager;
+  private GameStateDto gameStateDto;
+  private List<CardDto> cardDtoList;
+  private Lobby mockLobby;
+  private GameManager mockGameManager;
+
+  private static final Team redTeam = Team.RED;
+  private static final Role spymaster = Role.SPYMASTER;
+
+  @BeforeEach
+  void setUp() {
+    restorationMapper = mock(RestorationMapper.class);
+    lobbyService = mock(LobbyService.class);
+    lobbyRepository = mock(LobbyRepository.class);
+    gameManagerFactory = mock(GameManagerFactory.class);
+    gameService = mock(GameService.class);
+    transactionManager = mock(PlatformTransactionManager.class);
+    transactionStatus = mock(TransactionStatus.class);
+
+
+    mockLobby = mock(Lobby.class);
+    mockGameManager = mock(GameManager.class);
+
+    cardDtoList = List.of(new CardDto("TEST", null, false));
+    gameStateDto =
+        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), cardDtoList);
+
+    when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+
+    restorationService =
+        new RestorationService(
+            restorationMapper,
+            lobbyRepository,
+            lobbyService,
+            gameService,
+            gameManagerFactory,
+            transactionManager);
+  }
+
+  @Test
+  void testRestoreOnContainerStart() {
+    LobbyEntity lobbyEntity = new LobbyEntity();
+    lobbyEntity.setLobbyCode("ABCDE");
+    when(lobbyRepository.findAll()).thenReturn(List.of(lobbyEntity));
+
+    when(restorationMapper.mapToGameStateDto(lobbyEntity)).thenReturn(gameStateDto);
+    when(restorationMapper.mapToLobby(lobbyEntity)).thenReturn(mockLobby);
+    when(gameManagerFactory.createFromSnapshot(gameStateDto)).thenReturn(mockGameManager);
+
+    restorationService.restoreOnContainerStart();
+
+    verify(lobbyService, times(1)).restoreLobby("ABCDE", mockLobby);
+    verify(gameService, times(1)).restoreGameManager("ABCDE", mockGameManager);
+  }
+}


### PR DESCRIPTION
## Context
This PR contains the addition of a restoration feature to re-create lobbies and games when the container dies and restarts.

## Description
* 2 Classes were added, a mapping (helper) and a service restoration class. Service class is has PostConstruct annotated method that will be called when the container comes back up again. 
* Lobby and GameManagers will be recreated from the information stored in the database.

## Changes in the code base
* Addition of Mapping Class
* Addition of Service Class
* Service Class uses existing infrastructure from GameService and LobbyService to recreate active games and lobbies.

## Changes outside the code base
**N/A**

## Additional information
**N/A**