### PR TITLE
Fix: corrected guess responses

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: codenames
+      POSTGRES_USER: codenames_user
+      POSTGRES_PASSWORD: codenames_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "53213:8080"
+    volumes:
+      - ./data:/app/data
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/codenames
+      SPRING_DATASOURCE_USERNAME: codenames_user
+      SPRING_DATASOURCE_PASSWORD: codenames_pass
+    depends_on:
+      postgres:
+        condition: service_started
+
+volumes:
+  postgres_data:

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -55,7 +55,8 @@ public class RestorationMapper {
       clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
     }
     List<CardDto> cardList = mapToCardDto(lobbyEntity);
-    return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList);
+    return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList,
+            gameStateEntity.getRemainingGuesses());
   }
 
   private List<CardDto> mapToCardDto(LobbyEntity lobbyEntity) {

--- a/src/main/java/com/codenames/codenames/backend/game/api/dto/GameStateDto.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/dto/GameStateDto.java
@@ -18,4 +18,5 @@ public record GameStateDto(
     Team currentTurn,
     Role currentPhase,
     ClueDto currentClue,
-    List<CardDto> cardList) {}
+    List<CardDto> cardList,
+    int remainingGuesses) {}

--- a/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
@@ -53,7 +53,8 @@ public class DataTransferObjectService {
           currentTurn,
           currentPhase,
           null,
-              cardDataTransferObject);
+              cardDataTransferObject,
+              gameManager.getRemainingGuesses());
     }
     String word = gameManager.getCurrentClue().word();
     int guessAmount = gameManager.getCurrentClue().guessAmount();
@@ -62,6 +63,7 @@ public class DataTransferObjectService {
         currentTurn,
         currentPhase,
         new ClueDto(word, guessAmount),
-            cardDataTransferObject);
+            cardDataTransferObject,
+            gameManager.getRemainingGuesses());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
@@ -57,7 +57,7 @@ class RestorationServiceTest {
 
     cardDtoList = List.of(new CardDto("TEST", null, false));
     gameStateDto =
-        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), cardDtoList);
+        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), cardDtoList, 1);
 
     when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
 

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -106,6 +106,6 @@ class GameSocketControllerTest {
   }
 
   private GameStateDto createGameStateDto() {
-    return new GameStateDto(null, Team.RED, null, null, List.of());
+    return new GameStateDto(null, Team.RED, null, null, List.of(), 0);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
@@ -114,7 +114,7 @@ class GameServiceTest {
             redTeam,
             Role.SPYMASTER,
             new ClueDto("ANIMAL", 2),
-                List.of(new CardDto("Dog", Color.RED, false)));
+                List.of(new CardDto("Dog", Color.RED, false)), 2);
     when(mockGameManager.getCurrentTurn()).thenReturn(redTeam);
     when(mockGameManager.getCurrentPhase()).thenReturn(Role.SPYMASTER);
     when(mockGameManager.getRemainingGuesses()).thenReturn(2);
@@ -144,7 +144,7 @@ class GameServiceTest {
             redTeam,
             Role.SPYMASTER,
             new ClueDto("ANIMAL", 2),
-                List.of(new CardDto("Dog", Color.RED, false)));
+                List.of(new CardDto("Dog", Color.RED, false)), 2);
 
     when(mockGameManager.getCurrentTurn()).thenReturn(redTeam);
     when(mockGameManager.getCurrentPhase()).thenReturn(Role.SPYMASTER);

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerFactoryTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerFactoryTest.java
@@ -44,7 +44,7 @@ class GameManagerFactoryTest {
             Team.BLUE,
             Role.OPERATIVE,
             new ClueDto("ANIMAL", 2),
-            List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)));
+            List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)), 2);
 
     GameManager recovered = gameManagerFactory.createFromSnapshot(snapshot);
 
@@ -62,7 +62,7 @@ class GameManagerFactoryTest {
   void testCreateFromSnapshotWithoutClue() {
     GameStateDto snapshot =
         new GameStateDto(
-            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)));
+            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)), 2);
 
     GameManager recovered = gameManagerFactory.createFromSnapshot(snapshot);
 
@@ -84,7 +84,8 @@ class GameManagerFactoryTest {
                 new CardDto("Dog", Color.RED, true),
                 new CardDto("Cat", Color.RED, false),
                 new CardDto("Tree", Color.BLUE, true),
-                new CardDto("Sun", Color.NEUTRAL, true)));
+                new CardDto("Sun", Color.NEUTRAL, true)),
+                2);
 
     GameManager recovered = gameManagerFactory.createFromSnapshot(snapshot);
 

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
@@ -335,7 +335,7 @@ class GameManagerTest {
   @Test
   void recoveryConstructorThrowsWhenCardsAreNull() {
     GameStateDto state =
-        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, null);
+        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, null, 0);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -344,7 +344,7 @@ class GameManagerTest {
   @Test
   void recoveryConstructorThrowsWhenCardsAreEmpty() {
     GameStateDto state =
-        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, List.of());
+        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, List.of(), 0);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -356,7 +356,7 @@ class GameManagerTest {
         List.of(new CardDto("Dog", Color.RED, false));
 
     GameStateDto state =
-        new GameStateDto(null, null, Role.SPYMASTER, null, cards);
+        new GameStateDto(null, null, Role.SPYMASTER, null, cards, 0);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -368,7 +368,7 @@ class GameManagerTest {
         List.of(new CardDto("Dog", Color.RED, false));
 
     GameStateDto state =
-        new GameStateDto(null, Team.RED, null, null, cards);
+        new GameStateDto(null, Team.RED, null, null, cards, 0);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -383,7 +383,7 @@ class GameManagerTest {
 
     GameStateDto state =
         new GameStateDto(
-            Team.RED, Team.BLUE, Role.OPERATIVE, new ClueDto("ANIMAL", 2), cards);
+            Team.RED, Team.BLUE, Role.OPERATIVE, new ClueDto("ANIMAL", 2), cards, 2);
 
     GameManager restored = new GameManager(state, mockClueValidationService);
 

--- a/src/test/java/com/codenames/codenames/backend/lobby/api/LobbySocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/api/LobbySocketControllerTest.java
@@ -166,6 +166,6 @@ class LobbySocketControllerTest {
   }
 
   private GameStateDto createGameStatePayload() {
-    return new GameStateDto(null, null, null, null, List.of());
+    return new GameStateDto(null, null, null, null, List.of(), 0);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
@@ -72,7 +72,8 @@ class SystemStateRecoveryServiceTest {
             Team.RED,
             Role.OPERATIVE,
             new ClueDto("ANIMAL", 2),
-            List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)));
+            List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)),
+                2);
     SystemSnapshot snapshot =
         new SystemSnapshot(
             SystemSnapshot.CURRENT_SCHEMA_VERSION,
@@ -208,7 +209,7 @@ class SystemStateRecoveryServiceTest {
     TestContext context = createContext(tempDir.resolve("state-lobbies-null-games-present.json"));
     GameStateDto gameSnapshot =
         new GameStateDto(
-            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)));
+            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)), 0);
     SystemSnapshot snapshot =
         new SystemSnapshot(
             SystemSnapshot.CURRENT_SCHEMA_VERSION, null, Map.of("ABCDE", gameSnapshot));

--- a/src/test/java/com/codenames/codenames/backend/recovery/infrastructure/JsonStateStoreTest.java
+++ b/src/test/java/com/codenames/codenames/backend/recovery/infrastructure/JsonStateStoreTest.java
@@ -59,7 +59,7 @@ class JsonStateStoreTest {
 
     GameStateDto gameSnapshot =
         new GameStateDto(
-            null, Team.RED, Role.OPERATIVE, new ClueDto("ANIMAL", 2), List.of());
+            null, Team.RED, Role.OPERATIVE, new ClueDto("ANIMAL", 2), List.of(), 2);
 
     SystemSnapshot expectedSnapshot =
         new SystemSnapshot(

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -36,7 +36,7 @@ class SerializationJsonTest {
 
     dummyList = List.of(new CardDto("TEST", null, false));
     dummyGameState =
-        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), dummyList);
+        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), dummyList, 1);
   }
 
   @Test
@@ -44,7 +44,7 @@ class SerializationJsonTest {
     String expectedResult = "{\"winner\":\"RED\",\"currentTurn\":\"RED\","
         + "\"currentPhase\":\"SPYMASTER\",\"currentClue\":{\"word\":\"Test\","
         + "\"guessAmount\":1},\"cardList\":[{\"word\":\"TEST\","
-        + "\"color\":null,\"isGuessed\":false}]}";
+        + "\"color\":null,\"isGuessed\":false}],\"remainingGuesses\":1}";
     String result = serializer.serialize(dummyGameState);
     assertEquals(expectedResult, result);
   }


### PR DESCRIPTION
# Context
We had a bug, where the backend would not send the updated guess count after a card was revealed. This was corrected. Connected issue: #159 

# Changes in the codebase
A parameter has been re-added to GameStateDto, that counts the remaining guesses. Previously, only the original guess count was sent. I chose to always send both, to enable a view of the used guesses in respective to the original ones, displayed as ``` Remaining guesses: 2/3``` 

# Changes outside the codebase
Added a simple docker-compose file for local development. The container build by this is reachable over ```localhost:53213```.
Start the local container via ``docker compose -f docker-compose.dev.yml up -d --build ``.

# Additional information
N/A