### PR TITLE
Fix/163 write to db on card flip

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -45,6 +45,7 @@ public class PersistenceService {
   public void saveSnapShot(String lobbyCode) {
     log.info("Saving snapshot of lobby: {}", lobbyCode);
     GameManager gameManager = gameService.getGameState(lobbyCode);
+    log.info("Card state for lobby {}: {}", lobbyCode, gameManager.getCardList());
     List<PlayerDto> playerList = lobbyService.getPlayersDto(lobbyCode);
     LobbyEntity lobbySnapShot =
         persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerList);

--- a/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
@@ -68,6 +68,7 @@ public class GameSocketController {
   public void revealCard(RevealCardMessage message) {
 
     gameService.flipCard(message.getLobbyCode(), message.getPosition(), message.getCurrentTurn());
+    persistenceService.saveSnapShot(message.getLobbyCode());
 
     messagingTemplate.convertAndSend(
         GAME_TOPIC_PREFIX + message.getLobbyCode(),

--- a/src/main/java/com/codenames/codenames/backend/game/domain/Card.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/Card.java
@@ -1,9 +1,11 @@
 package com.codenames.codenames.backend.game.domain;
 
 import lombok.Getter;
+import lombok.ToString;
 
 /** Represents a single card on a board. */
 @Getter
+@ToString
 public class Card {
   private final String word;
   private final Color color;

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -68,6 +68,7 @@ class GameSocketControllerTest {
     controller.revealCard(message);
 
     verify(gameService).flipCard(LOBBY_CODE, 0, Team.RED);
+    verify(persistenceService).saveSnapShot(LOBBY_CODE);
     verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
   }
 


### PR DESCRIPTION
## Context
This PR contains a fix to the DB persistence service. 

## Description
Originally we would only write to the DB when we change turns. That missed the scenario where the container would crash and players would lose their guessed cards, making the storage of remaining guesses obsolete, as it would always be equal the original guess amount, since we would only save one the turn was over.

## Changes in the code base
* Add logging to ease testing
* Add persistence call when a card is flipped

## Changes outside the code base
**N/A**

## Additional information
**N/A**