### PR TITLE
Fix/add remaining guesses to restoration

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -54,8 +54,10 @@ public class RestorationMapper {
     if (gameStateEntity.getClueWord() != null) {
       clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
     }
+    int remainingGuesses = gameStateEntity.getRemainingGuesses()
     List<CardDto> cardList = mapToCardDto(lobbyEntity);
-    return new GameStateDto(winner, currentTeam, currentPhase, clueDto, cardList);
+    return new GameStateDto(winner, currentTeam, currentPhase, clueDto,
+        remainingGuesses, cardList);
   }
 
   private List<CardDto> mapToCardDto(LobbyEntity lobbyEntity) {

--- a/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
+++ b/src/main/java/com/codenames/codenames/backend/database/restoration/RestorationMapper.java
@@ -54,7 +54,7 @@ public class RestorationMapper {
     if (gameStateEntity.getClueWord() != null) {
       clueDto = new ClueDto(gameStateEntity.getClueWord(), gameStateEntity.getClueGuessAmount());
     }
-    int remainingGuesses = gameStateEntity.getRemainingGuesses()
+    int remainingGuesses = gameStateEntity.getRemainingGuesses();
     List<CardDto> cardList = mapToCardDto(lobbyEntity);
     return new GameStateDto(winner, currentTeam, currentPhase, clueDto,
         remainingGuesses, cardList);

--- a/src/main/java/com/codenames/codenames/backend/game/api/dto/GameStateDto.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/dto/GameStateDto.java
@@ -18,4 +18,5 @@ public record GameStateDto(
     Team currentTurn,
     Role currentPhase,
     ClueDto currentClue,
+    int remainingGuesses,
     List<CardDto> cardList) {}

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -87,6 +87,7 @@ public class GameManager {
         state.currentClue() == null
             ? null
             : new Clue(state.currentClue().word(), state.currentClue().guessAmount());
+    this.remainingGuesses = state.remainingGuesses();
     this.clueValidationService = clueValidationService;
 
     List<Card> cards = state.cardList().stream().map(this::toCard).toList();

--- a/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/mapping/DataTransferObjectService.java
@@ -47,13 +47,15 @@ public class DataTransferObjectService {
     if (gameManager.getWinner() != null) {
       log.info("A Game is over. Winner is {}.", gameManager.getWinner());
     }
+    int remainingGuesses = gameManager.getRemainingGuesses();
     if (gameManager.getCurrentClue() == null) {
       return new GameStateDto(
           gameManager.getWinner(),
           currentTurn,
           currentPhase,
           null,
-              cardDataTransferObject);
+          remainingGuesses,
+          cardDataTransferObject);
     }
     String word = gameManager.getCurrentClue().word();
     int guessAmount = gameManager.getCurrentClue().guessAmount();
@@ -62,6 +64,7 @@ public class DataTransferObjectService {
         currentTurn,
         currentPhase,
         new ClueDto(word, guessAmount),
-            cardDataTransferObject);
+        remainingGuesses,
+        cardDataTransferObject);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/restoration/RestorationServiceTest.java
@@ -57,7 +57,7 @@ class RestorationServiceTest {
 
     cardDtoList = List.of(new CardDto("TEST", null, false));
     gameStateDto =
-        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), cardDtoList);
+        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), 2, cardDtoList);
 
     when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
 

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -106,6 +106,6 @@ class GameSocketControllerTest {
   }
 
   private GameStateDto createGameStateDto() {
-    return new GameStateDto(null, Team.RED, null, null, List.of());
+    return new GameStateDto(null, Team.RED, null, null, 0, List.of());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
@@ -114,6 +114,7 @@ class GameServiceTest {
             redTeam,
             Role.SPYMASTER,
             new ClueDto("ANIMAL", 2),
+            3,
                 List.of(new CardDto("Dog", Color.RED, false)));
     when(mockGameManager.getCurrentTurn()).thenReturn(redTeam);
     when(mockGameManager.getCurrentPhase()).thenReturn(Role.SPYMASTER);
@@ -144,6 +145,7 @@ class GameServiceTest {
             redTeam,
             Role.SPYMASTER,
             new ClueDto("ANIMAL", 2),
+            3,
                 List.of(new CardDto("Dog", Color.RED, false)));
 
     when(mockGameManager.getCurrentTurn()).thenReturn(redTeam);

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerFactoryTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerFactoryTest.java
@@ -44,6 +44,7 @@ class GameManagerFactoryTest {
             Team.BLUE,
             Role.OPERATIVE,
             new ClueDto("ANIMAL", 2),
+            3,
             List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)));
 
     GameManager recovered = gameManagerFactory.createFromSnapshot(snapshot);
@@ -62,7 +63,7 @@ class GameManagerFactoryTest {
   void testCreateFromSnapshotWithoutClue() {
     GameStateDto snapshot =
         new GameStateDto(
-            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)));
+            null, Team.BLUE, Role.SPYMASTER, null, 0, List.of(new CardDto("Tree", Color.BLUE, false)));
 
     GameManager recovered = gameManagerFactory.createFromSnapshot(snapshot);
 
@@ -80,6 +81,7 @@ class GameManagerFactoryTest {
             Team.RED,
             Role.OPERATIVE,
             null,
+            0,
             List.of(
                 new CardDto("Dog", Color.RED, true),
                 new CardDto("Cat", Color.RED, false),

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
@@ -335,7 +335,7 @@ class GameManagerTest {
   @Test
   void recoveryConstructorThrowsWhenCardsAreNull() {
     GameStateDto state =
-        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, null);
+        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, 0, null);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -344,7 +344,7 @@ class GameManagerTest {
   @Test
   void recoveryConstructorThrowsWhenCardsAreEmpty() {
     GameStateDto state =
-        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, List.of());
+        new GameStateDto(null, Team.RED, Role.SPYMASTER, null, 0, List.of());
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -356,7 +356,7 @@ class GameManagerTest {
         List.of(new CardDto("Dog", Color.RED, false));
 
     GameStateDto state =
-        new GameStateDto(null, null, Role.SPYMASTER, null, cards);
+        new GameStateDto(null, null, Role.SPYMASTER, null, 0, cards);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -368,7 +368,7 @@ class GameManagerTest {
         List.of(new CardDto("Dog", Color.RED, false));
 
     GameStateDto state =
-        new GameStateDto(null, Team.RED, null, null, cards);
+        new GameStateDto(null, Team.RED, null, null, 0, cards);
 
     assertThrows(
         IllegalArgumentException.class, () -> new GameManager(state, mockClueValidationService));
@@ -383,7 +383,7 @@ class GameManagerTest {
 
     GameStateDto state =
         new GameStateDto(
-            Team.RED, Team.BLUE, Role.OPERATIVE, new ClueDto("ANIMAL", 2), cards);
+            Team.RED, Team.BLUE, Role.OPERATIVE, new ClueDto("ANIMAL", 2), 3, cards);
 
     GameManager restored = new GameManager(state, mockClueValidationService);
 

--- a/src/test/java/com/codenames/codenames/backend/lobby/api/LobbySocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/api/LobbySocketControllerTest.java
@@ -166,6 +166,6 @@ class LobbySocketControllerTest {
   }
 
   private GameStateDto createGameStatePayload() {
-    return new GameStateDto(null, null, null, null, List.of());
+    return new GameStateDto(null, null, null, null, 0, List.of());
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
@@ -72,6 +72,7 @@ class SystemStateRecoveryServiceTest {
             Team.RED,
             Role.OPERATIVE,
             new ClueDto("ANIMAL", 2),
+            3,
             List.of(new CardDto("Dog", Color.RED, true), new CardDto("Cat", Color.BLUE, false)));
     SystemSnapshot snapshot =
         new SystemSnapshot(
@@ -208,7 +209,7 @@ class SystemStateRecoveryServiceTest {
     TestContext context = createContext(tempDir.resolve("state-lobbies-null-games-present.json"));
     GameStateDto gameSnapshot =
         new GameStateDto(
-            null, Team.BLUE, Role.SPYMASTER, null, List.of(new CardDto("Tree", Color.BLUE, false)));
+            null, Team.BLUE, Role.SPYMASTER, null, 0, List.of(new CardDto("Tree", Color.BLUE, false)));
     SystemSnapshot snapshot =
         new SystemSnapshot(
             SystemSnapshot.CURRENT_SCHEMA_VERSION, null, Map.of("ABCDE", gameSnapshot));

--- a/src/test/java/com/codenames/codenames/backend/recovery/infrastructure/JsonStateStoreTest.java
+++ b/src/test/java/com/codenames/codenames/backend/recovery/infrastructure/JsonStateStoreTest.java
@@ -59,7 +59,7 @@ class JsonStateStoreTest {
 
     GameStateDto gameSnapshot =
         new GameStateDto(
-            null, Team.RED, Role.OPERATIVE, new ClueDto("ANIMAL", 2), List.of());
+            null, Team.RED, Role.OPERATIVE, new ClueDto("ANIMAL", 2), 3, List.of());
 
     SystemSnapshot expectedSnapshot =
         new SystemSnapshot(

--- a/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
+++ b/src/test/java/com/codenames/codenames/backend/serialization/SerializationJsonTest.java
@@ -36,15 +36,16 @@ class SerializationJsonTest {
 
     dummyList = List.of(new CardDto("TEST", null, false));
     dummyGameState =
-        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), dummyList);
+        new GameStateDto(redTeam, redTeam, spymaster, new ClueDto("Test", 1), 2, dummyList);
   }
 
   @Test
   void testSerialize_pass() {
-    String expectedResult = "{\"winner\":\"RED\",\"currentTurn\":\"RED\","
-        + "\"currentPhase\":\"SPYMASTER\",\"currentClue\":{\"word\":\"Test\","
-        + "\"guessAmount\":1},\"cardList\":[{\"word\":\"TEST\","
-        + "\"color\":null,\"isGuessed\":false}]}";
+    String expectedResult =
+        "{\"winner\":\"RED\",\"currentTurn\":\"RED\","
+            + "\"currentPhase\":\"SPYMASTER\",\"currentClue\":{\"word\":\"Test\","
+            + "\"guessAmount\":1},\"remainingGuesses\":2,\"cardList\":[{\"word\":\"TEST\","
+            + "\"color\":null,\"isGuessed\":false}]}";
     String result = serializer.serialize(dummyGameState);
     assertEquals(expectedResult, result);
   }


### PR DESCRIPTION
## Context
This PR contains a fix to the DB persistence service. 

## Description
Originally GameStateDto did not contain remaining guesses, hence the mapping and restoration did not include them. 

## Changes in the code base
* Update Dto in backend (frontend needs to update Dto too)
* Add mapping and restoration of remaining guesses
* Update all methods and tests using Dto

## Changes outside the code base
**N/A**

## Additional information
**N/A**