### PR TITLE
Feature/135 delete db entry when lobby deleted

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/lobby/application/LobbyService.java
+++ b/src/main/java/com/codenames/codenames/backend/lobby/application/LobbyService.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.lobby.application;
 
 import com.codenames.codenames.backend.chat.application.ChatService;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
@@ -30,6 +31,7 @@ public class LobbyService {
   private final LobbyCodeGenerator generator;
   private final GameService gameService;
   private final ChatService chatService;
+  private final LobbyRepository lobbyRepository;
 
   /**
    * Creates a new {@code LobbyService}.
@@ -37,10 +39,11 @@ public class LobbyService {
    * @param generator the lobby code generator used to create unique lobby codes
    */
   public LobbyService(
-      LobbyCodeGenerator generator, ChatService chatService, GameService gameService) {
+      LobbyCodeGenerator generator, ChatService chatService, GameService gameService, LobbyRepository lobbyRepository) {
     this.generator = generator;
     this.chatService = chatService;
     this.gameService = gameService;
+    this.lobbyRepository = lobbyRepository;
   }
 
   /**
@@ -158,6 +161,7 @@ public class LobbyService {
       lobbyList.remove(lobbyCode);
       chatService.clearLobbyHistory(lobbyCode);
       gameService.removeGame(lobbyCode);
+      lobbyRepository.deleteById(lobbyCode);
       log.info("{}: Lobby is empty, was removed from list.", lobbyCode);
     }
   }

--- a/src/main/java/com/codenames/codenames/backend/lobby/application/LobbyService.java
+++ b/src/main/java/com/codenames/codenames/backend/lobby/application/LobbyService.java
@@ -26,8 +26,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class LobbyService {
 
-  @Getter
-  private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
+  @Getter private final Map<String, Lobby> lobbyList = new ConcurrentHashMap<>();
   private final LobbyCodeGenerator generator;
   private final GameService gameService;
   private final ChatService chatService;
@@ -39,7 +38,10 @@ public class LobbyService {
    * @param generator the lobby code generator used to create unique lobby codes
    */
   public LobbyService(
-      LobbyCodeGenerator generator, ChatService chatService, GameService gameService, LobbyRepository lobbyRepository) {
+      LobbyCodeGenerator generator,
+      ChatService chatService,
+      GameService gameService,
+      LobbyRepository lobbyRepository) {
     this.generator = generator;
     this.chatService = chatService;
     this.gameService = gameService;

--- a/src/test/java/com/codenames/codenames/backend/lobby/application/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/application/LobbyServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.chat.application.ChatService;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.lobby.api.dto.PlayerDto;
 import com.codenames.codenames.backend.lobby.domain.Lobby;
@@ -37,14 +38,16 @@ class LobbyServiceTest {
   private LobbyService lobbyService;
   private LobbyCodeGenerator generator;
   private GameService gameService;
+  private LobbyRepository lobbyRepository;
 
   @BeforeEach
   void setup() {
     generator = mock(LobbyCodeGenerator.class);
     gameService = mock(GameService.class);
     ChatService chatService = mock(ChatService.class);
+    lobbyRepository = mock(LobbyRepository.class);
 
-    lobbyService = new LobbyService(generator, chatService, gameService);
+    lobbyService = new LobbyService(generator, chatService, gameService, lobbyRepository);
     when(generator.generateLobbyCode()).thenReturn("ABCDE");
   }
 

--- a/src/test/java/com/codenames/codenames/backend/lobby/application/LobbyServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/lobby/application/LobbyServiceTest.java
@@ -266,6 +266,7 @@ class LobbyServiceTest {
     lobbyService.checkLobbyStillHasPlayers("ABCDE");
     assertFalse(lobbyService.getLobbyList().containsKey("ABCDE"));
     verify(gameService, times(1)).removeGame("ABCDE");
+    verify(lobbyRepository, times(1)).deleteById("ABCDE");
   }
 
   @Test

--- a/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/recovery/application/SystemStateRecoveryServiceTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.codenames.codenames.backend.chat.application.ChatService;
+import com.codenames.codenames.backend.database.repository.LobbyRepository;
 import com.codenames.codenames.backend.game.api.dto.CardDto;
 import com.codenames.codenames.backend.game.api.dto.ClueDto;
 import com.codenames.codenames.backend.game.api.dto.GameStateDto;
@@ -29,12 +31,19 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class SystemStateRecoveryServiceTest {
 
+  private LobbyRepository lobbyRepository;
   @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    lobbyRepository = mock(LobbyRepository.class);
+  }
 
   @Test
   void recoverOnStartupDoesNothingWhenNoSnapshotExists() {
@@ -242,7 +251,8 @@ class SystemStateRecoveryServiceTest {
             new CardGenerator("CodenamesWordlist.txt"), new ClueValidationService());
     GameService gameService = new GameService(gameManagerFactory, new DataTransferObjectService());
     LobbyService lobbyService =
-        new LobbyService(new LobbyCodeGenerator(), new ChatService(null), gameService);
+        new LobbyService(
+            new LobbyCodeGenerator(), new ChatService(null), gameService, lobbyRepository);
     SystemStateRecoveryService recoveryService =
         new SystemStateRecoveryService(stateStore, lobbyService, gameService, gameManagerFactory);
 


### PR DESCRIPTION
## Context
This PR contains the feature to delete lobby entreis from the DB. 

## Description
When a lobby has no player left, it is closed and deleted. The DB should react accordingly and also delete its entries to not waste space. This PR adds the deletion when in memory lobbies are deleted.

## Changes in the code base
* Add deletion of DB entries to LobbyService
* Update all classes and test suites that use an actual instance of LobbyService to also take LobbyRepository as a constructor argument
* Verified that deletion is called when a lobby is deleted

## Changes outside the code base
**N/A**

## Additional information
**N/A**