### PR TITLE
fix: to avoid uniqueness violation we try deleting and inserting

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
+++ b/src/main/java/com/codenames/codenames/backend/database/persistence/PersistenceService.java
@@ -49,6 +49,8 @@ public class PersistenceService {
     List<PlayerDto> playerList = lobbyService.getPlayersDto(lobbyCode);
     LobbyEntity lobbySnapShot =
         persistenceMapper.mapAggregateParentLobbyEntity(lobbyCode, gameManager, playerList);
+    lobbyRepository.deleteById(lobbyCode);
+    lobbyRepository.flush();
     lobbyRepository.save(lobbySnapShot);
     log.info("Snapshot has been saved to DB");
   }

--- a/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/database/persistence/PersistenceServiceTest.java
@@ -163,4 +163,11 @@ class PersistenceServiceTest {
     assertEquals("RED", cardList.get(24).getColor());
     assertFalse(cardList.get(24).getIsGuessed());
   }
+
+  @Test
+  void testSaveSnapshot_noUniquenessViolationOnSecondSave() {
+    persistenceService.saveSnapShot(lobbyCode);
+    persistenceService.saveSnapShot(lobbyCode);
+    assertEquals(lobbyCode, lobbyRepository.findById(lobbyCode).get().getLobbyCode());
+  }
 }


### PR DESCRIPTION
## Context
This PR contains a fix to the DB uniqueness violation problem when creating a second snapshot. 

## Description
Currently the saving to the DB works once, the second creates a uniqueness violation. A simple fix would be to delete the old entry and reinsert it. 

## Changes in the code base
* Delete the old entry and insert a fresh lobby entry.

## Changes outside the code base
**N/A**

## Additional information
**N/A**