### PR TITLE
Feature/124 cheat detection

### DIFF
--- a/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
@@ -89,6 +89,25 @@ public class GameSocketController {
   }
 
   /**
+   * Handles an expose-cheat request and broadcasts the updated game state.
+   *
+   * @param message the expose-cheat request containing lobby and username
+   */
+  @MessageMapping("/expose-cheat")
+  public void exposeCheat(CheatCardMessage message) {
+
+    cheatService.exposeCheat(
+        message.getLobbyCode(),
+        message.getUsername());
+
+    persistenceService.saveSnapShot(message.getLobbyCode());
+
+    messagingTemplate.convertAndSend(
+        GAME_TOPIC_PREFIX + message.getLobbyCode(),
+        gameService.getCurrentGameState(message.getLobbyCode()));
+  }
+
+  /**
    * Sends the current game state to subscribed players.
    *
    * @param message contains the lobby code

--- a/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
+++ b/src/main/java/com/codenames/codenames/backend/game/api/GameSocketController.java
@@ -12,6 +12,7 @@ import com.codenames.codenames.backend.game.application.CheatService;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.game.domain.CheatResult;
 import com.codenames.codenames.backend.game.domain.Clue;
+import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
@@ -96,9 +97,30 @@ public class GameSocketController {
   @MessageMapping("/expose-cheat")
   public void exposeCheat(CheatCardMessage message) {
 
-    cheatService.exposeCheat(
-        message.getLobbyCode(),
-        message.getUsername());
+    ExposeCheatResult result =
+        cheatService.exposeCheat(
+            message.getLobbyCode(),
+            message.getUsername());
+
+    if (result == null) {
+      return;
+    }
+
+    ChatDto systemMessage =
+        new ChatDto(
+            "System",
+            result.correct()
+                ? "EXPOSE_CORRECT"
+                : "EXPOSE_WRONG",
+            ChatMessageType.SYSTEM);
+
+    messagingTemplate.convertAndSend(
+        "/topic/chat/"
+            + message.getLobbyCode()
+            + "/"
+            + result.team()
+            + "/operative",
+        systemMessage);
 
     persistenceService.saveSnapShot(message.getLobbyCode());
 

--- a/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.game.application;
 
 import com.codenames.codenames.backend.game.domain.CheatResult;
+import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
@@ -49,16 +50,17 @@ public class CheatService {
    *
    * @param lobbyCode the lobby code
    * @param username the requesting username
-   * @return true if the opposing team has used their cheat, false otherwise
+   * @return the expose-cheat result or null if the request is invalid
    */
-  public boolean exposeCheat(String lobbyCode, String username) {
+  public ExposeCheatResult exposeCheat(String lobbyCode, String username) {
     Team team = lobbyService.getPlayerTeam(username, lobbyCode);
     Role role = lobbyService.getPlayerRole(username, lobbyCode);
 
     if (team == null || role != Role.OPERATIVE) {
-      return false;
+      return null;
     }
 
-    return gameService.exposeCheatAndApplyPenalty(lobbyCode, team);
+    boolean correct = gameService.exposeCheatAndApplyPenalty(lobbyCode, team);
+    return new ExposeCheatResult(correct, team);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
@@ -3,6 +3,7 @@ package com.codenames.codenames.backend.game.application;
 import com.codenames.codenames.backend.game.domain.CheatResult;
 import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
+import com.codenames.codenames.backend.lobby.domain.Player;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.List;
@@ -35,8 +36,13 @@ public class CheatService {
    * @return the cheat result or null if the request is invalid
    */
   public CheatResult useCheat(String lobbyCode, String username, List<Integer> positions) {
-    Team team = lobbyService.getPlayerTeam(username, lobbyCode);
-    Role role = lobbyService.getPlayerRole(username, lobbyCode);
+    Player player = lobbyService.getPlayer(lobbyCode, username);
+    if (player == null) {
+      return null;
+    }
+
+    Team team = lobbyService.getPlayerTeam(player.uuid(), lobbyCode);
+    Role role = lobbyService.getPlayerRole(player.uuid(), lobbyCode);
 
     if (team == null || role != Role.OPERATIVE) {
       return null;
@@ -53,8 +59,13 @@ public class CheatService {
    * @return the expose-cheat result or null if the request is invalid
    */
   public ExposeCheatResult exposeCheat(String lobbyCode, String username) {
-    Team team = lobbyService.getPlayerTeam(username, lobbyCode);
-    Role role = lobbyService.getPlayerRole(username, lobbyCode);
+    Player player = lobbyService.getPlayer(lobbyCode, username);
+    if (player == null) {
+      return null;
+    }
+
+    Team team = lobbyService.getPlayerTeam(player.uuid(), lobbyCode);
+    Role role = lobbyService.getPlayerRole(player.uuid(), lobbyCode);
 
     if (team == null || role != Role.OPERATIVE) {
       return null;

--- a/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
@@ -36,15 +36,8 @@ public class CheatService {
    * @return the cheat result or null if the request is invalid
    */
   public CheatResult useCheat(String lobbyCode, String username, List<Integer> positions) {
-    Player player = lobbyService.getPlayer(lobbyCode, username);
-    if (player == null) {
-      return null;
-    }
-
-    Team team = lobbyService.getPlayerTeam(player.uuid(), lobbyCode);
-    Role role = lobbyService.getPlayerRole(player.uuid(), lobbyCode);
-
-    if (team == null || role != Role.OPERATIVE) {
+    Team team = getOperativeTeam(lobbyCode, username);
+    if (team == null) {
       return null;
     }
 
@@ -59,6 +52,16 @@ public class CheatService {
    * @return the expose-cheat result or null if the request is invalid
    */
   public ExposeCheatResult exposeCheat(String lobbyCode, String username) {
+    Team team = getOperativeTeam(lobbyCode, username);
+    if (team == null) {
+      return null;
+    }
+
+    boolean correct = gameService.exposeCheatAndApplyPenalty(lobbyCode, team);
+    return new ExposeCheatResult(correct, team);
+  }
+
+  private Team getOperativeTeam(String lobbyCode, String username) {
     Player player = lobbyService.getPlayer(lobbyCode, username);
     if (player == null) {
       return null;
@@ -67,11 +70,6 @@ public class CheatService {
     Team team = lobbyService.getPlayerTeam(player.uuid(), lobbyCode);
     Role role = lobbyService.getPlayerRole(player.uuid(), lobbyCode);
 
-    if (team == null || role != Role.OPERATIVE) {
-      return null;
-    }
-
-    boolean correct = gameService.exposeCheatAndApplyPenalty(lobbyCode, team);
-    return new ExposeCheatResult(correct, team);
+    return role == Role.OPERATIVE ? team : null;
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/CheatService.java
@@ -43,4 +43,22 @@ public class CheatService {
 
     return gameService.useCheat(lobbyCode, positions, team);
   }
+
+  /**
+   * Performs an expose-cheat attempt for a player and applies the matching penalty.
+   *
+   * @param lobbyCode the lobby code
+   * @param username the requesting username
+   * @return true if the opposing team has used their cheat, false otherwise
+   */
+  public boolean exposeCheat(String lobbyCode, String username) {
+    Team team = lobbyService.getPlayerTeam(username, lobbyCode);
+    Role role = lobbyService.getPlayerRole(username, lobbyCode);
+
+    if (team == null || role != Role.OPERATIVE) {
+      return false;
+    }
+
+    return gameService.exposeCheatAndApplyPenalty(lobbyCode, team);
+  }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/application/GameService.java
+++ b/src/main/java/com/codenames/codenames/backend/game/application/GameService.java
@@ -180,4 +180,15 @@ public class GameService {
 
     return getGame(lobbyCode).useCheat(positions, team);
   }
+
+  /**
+   * Performs an expose-cheat attempt and applies the matching penalty.
+   *
+   * @param lobbyCode the lobby code of the game
+   * @param team the team trying to expose the opponent's cheat
+   * @return true if the opposing team has used their cheat, false otherwise
+   */
+  public boolean exposeCheatAndApplyPenalty(String lobbyCode, Team team) {
+    return getGame(lobbyCode).exposeCheatAndApplyPenalty(team);
+  }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/domain/ExposeCheatResult.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/ExposeCheatResult.java
@@ -1,0 +1,14 @@
+package com.codenames.codenames.backend.game.domain;
+
+import com.codenames.codenames.backend.lobby.domain.Team;
+
+/**
+ * Result of an expose-cheat attempt.
+ *
+ * @param correct whether the opposing team had used their cheat
+ * @param team the team that tried to expose the cheat
+ */
+public record ExposeCheatResult(
+    boolean correct,
+    Team team) {
+}

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -74,8 +74,7 @@ public class GameManager {
    * @param state bundled recovery state
    * @param clueValidationService clue validation service
    */
-  public GameManager(
-      GameStateDto state, ClueValidationService clueValidationService) {
+  public GameManager(GameStateDto state, ClueValidationService clueValidationService) {
     if (state.cardList() == null || state.cardList().isEmpty()) {
       throw new IllegalArgumentException("cards cannot be null or empty");
     }
@@ -364,16 +363,12 @@ public class GameManager {
    * @return true if the position is valid
    */
   private boolean isValidPosition(Integer position) {
-    return position != null
-        && position >= 0
-        && position < board.getCardList().size();
+    return position != null && position >= 0 && position < board.getCardList().size();
   }
 
   /**
-   * Performs the cheat action for the current team.
-   * The team may use the cheat only once per game.
-   * If at least one selected card belongs to the team,
-   * one correct card is returned.
+   * Performs the cheat action for the current team. The team may use the cheat only once per game.
+   * If at least one selected card belongs to the team, one correct card is returned.
    *
    * @param positions selected card positions
    * @param team the team requesting the cheat
@@ -428,6 +423,7 @@ public class GameManager {
 
     Card correctCard = correctCards.get(0);
 
-    return new CheatResult("The card \"" + correctCard.getWord() + "\" belongs to your team.", team);
+    return new CheatResult(
+        "The card \"" + correctCard.getWord() + "\" belongs to your team.", team);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -423,11 +423,11 @@ public class GameManager {
     }
 
     if (correctCards.isEmpty()) {
-      return new CheatResult("Keine der ausgewählten Karten ist richtig.", team);
+      return new CheatResult("None of the selected cards belongs to your team.", team);
     }
 
     Card correctCard = correctCards.get(0);
 
-    return new CheatResult("Die Karte \"" + correctCard.getWord() + "\" ist richtig.", team);
+    return new CheatResult("The card \"" + correctCard.getWord() + "\" belongs to your team.", team);
   }
 }

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -315,8 +315,8 @@ public class GameManager {
   /**
    * Applies the penalty for an expose-cheat attempt.
    *
-   * <p>If the exposure is correct, the current turn state is advanced. If it is wrong, the calling
-   * team pafeat(game-manager): add expose cheat penalty handlingsses their turn.
+   * <p>If the exposure is correct, the opposing team's next turn is skipped. If it is wrong, the
+   * calling team passes their turn.
    *
    * @param callingTeam the team trying to expose the opponent's cheat
    * @return true if the opposing team has used their cheat, false otherwise
@@ -325,12 +325,24 @@ public class GameManager {
     boolean correct = exposeCheat(callingTeam);
 
     if (correct) {
-      advanceTurn();
+      skipOpponentTurn(callingTeam);
     } else {
       passTurn(callingTeam);
     }
 
     return correct;
+  }
+
+  /**
+   * Skips the opposing team's full next turn after a correct expose-cheat attempt.
+   *
+   * @param callingTeam the team that correctly exposed the opponent's cheat
+   */
+  private void skipOpponentTurn(Team callingTeam) {
+    checkCorrectTurn(callingTeam, Role.OPERATIVE);
+    advanceTurn();
+    advanceTurn();
+    advanceTurn();
   }
 
   /**

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -299,6 +299,20 @@ public class GameManager {
   }
 
   /**
+   * Checks whether the opposing team has already used their cheat.
+   *
+   * @param callingTeam the team trying to expose the opponent's cheat
+   * @return true if the opposing team has used their cheat, false otherwise
+   */
+  public boolean exposeCheat(Team callingTeam) {
+    if (callingTeam == Team.RED) {
+      return blueTeamCheatUsed;
+    }
+
+    return redTeamCheatUsed;
+  }
+
+  /**
    * Helper method to check if the current team calling a method is allowed to do so.
    *
    * @param team the team of who is calling the method

--- a/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
+++ b/src/main/java/com/codenames/codenames/backend/game/domain/GameManager.java
@@ -313,6 +313,27 @@ public class GameManager {
   }
 
   /**
+   * Applies the penalty for an expose-cheat attempt.
+   *
+   * <p>If the exposure is correct, the current turn state is advanced. If it is wrong, the calling
+   * team pafeat(game-manager): add expose cheat penalty handlingsses their turn.
+   *
+   * @param callingTeam the team trying to expose the opponent's cheat
+   * @return true if the opposing team has used their cheat, false otherwise
+   */
+  public boolean exposeCheatAndApplyPenalty(Team callingTeam) {
+    boolean correct = exposeCheat(callingTeam);
+
+    if (correct) {
+      advanceTurn();
+    } else {
+      passTurn(callingTeam);
+    }
+
+    return correct;
+  }
+
+  /**
    * Helper method to check if the current team calling a method is allowed to do so.
    *
    * @param team the team of who is calling the method

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -161,4 +161,21 @@ class GameSocketControllerTest {
         .convertAndSendToUser(anyString(), anyString(), any(Object.class));
     verify(persistenceService, never()).saveSnapShot(LOBBY_CODE);
   }
+
+  @Test
+  void exposeCheatShouldPersistAndBroadcastUpdatedState() {
+    CheatCardMessage message = new CheatCardMessage();
+    message.setLobbyCode(LOBBY_CODE);
+    message.setUsername("Max");
+    message.setPositions(List.of());
+
+    when(gameService.getCurrentGameState(LOBBY_CODE))
+        .thenReturn(createGameStateDto());
+
+    controller.exposeCheat(message);
+
+    verify(cheatService).exposeCheat(LOBBY_CODE, "Max");
+    verify(persistenceService).saveSnapShot(LOBBY_CODE);
+    verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+  }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -130,7 +130,7 @@ class GameSocketControllerTest {
     message.setUsername("Max");
     message.setPositions(List.of(0, 1));
 
-    CheatResult result = new CheatResult("Die Karte \"Dog\" ist richtig.", Team.RED);
+    CheatResult result = new CheatResult("The card \"Dog\" belongs to your team.", Team.RED);
 
     when(cheatService.useCheat(LOBBY_CODE, "Max", List.of(0, 1))).thenReturn(result);
 

--- a/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/api/GameSocketControllerTest.java
@@ -18,6 +18,7 @@ import com.codenames.codenames.backend.game.api.dto.StartGameMessage;
 import com.codenames.codenames.backend.game.application.CheatService;
 import com.codenames.codenames.backend.game.application.GameService;
 import com.codenames.codenames.backend.game.domain.CheatResult;
+import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -168,14 +169,57 @@ class GameSocketControllerTest {
     message.setLobbyCode(LOBBY_CODE);
     message.setUsername("Max");
     message.setPositions(List.of());
+    GameStateDto gameState = createGameStateDto();
 
-    when(gameService.getCurrentGameState(LOBBY_CODE))
-        .thenReturn(createGameStateDto());
+    when(cheatService.exposeCheat(LOBBY_CODE, "Max"))
+        .thenReturn(new ExposeCheatResult(true, Team.RED));
+    when(gameService.getCurrentGameState(LOBBY_CODE)).thenReturn(gameState);
 
     controller.exposeCheat(message);
 
     verify(cheatService).exposeCheat(LOBBY_CODE, "Max");
+    verify(messagingTemplate)
+        .convertAndSend(
+            "/topic/chat/" + LOBBY_CODE + "/RED/operative",
+            new ChatDto("System", "EXPOSE_CORRECT", ChatMessageType.SYSTEM));
     verify(persistenceService).saveSnapShot(LOBBY_CODE);
-    verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+    verify(messagingTemplate).convertAndSend("/topic/game/" + LOBBY_CODE, gameState);
+  }
+
+  @Test
+  void exposeCheatShouldSendWrongSystemMessage() {
+    CheatCardMessage message = new CheatCardMessage();
+    message.setLobbyCode(LOBBY_CODE);
+    message.setUsername("Max");
+    message.setPositions(List.of());
+    GameStateDto gameState = createGameStateDto();
+
+    when(cheatService.exposeCheat(LOBBY_CODE, "Max"))
+        .thenReturn(new ExposeCheatResult(false, Team.BLUE));
+    when(gameService.getCurrentGameState(LOBBY_CODE)).thenReturn(gameState);
+
+    controller.exposeCheat(message);
+
+    verify(messagingTemplate)
+        .convertAndSend(
+            "/topic/chat/" + LOBBY_CODE + "/BLUE/operative",
+            new ChatDto("System", "EXPOSE_WRONG", ChatMessageType.SYSTEM));
+    verify(messagingTemplate).convertAndSend("/topic/game/" + LOBBY_CODE, gameState);
+  }
+
+  @Test
+  void exposeCheatShouldDoNothingWhenResultIsNull() {
+    CheatCardMessage message = new CheatCardMessage();
+    message.setLobbyCode(LOBBY_CODE);
+    message.setUsername("Max");
+    message.setPositions(List.of());
+
+    when(cheatService.exposeCheat(LOBBY_CODE, "Max")).thenReturn(null);
+
+    controller.exposeCheat(message);
+
+    verify(cheatService).exposeCheat(LOBBY_CODE, "Max");
+    verify(persistenceService, never()).saveSnapShot(LOBBY_CODE);
+    verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.codenames.codenames.backend.game.domain.CheatResult;
 import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
+import com.codenames.codenames.backend.lobby.domain.Player;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
 import java.util.List;
@@ -22,6 +23,8 @@ class CheatServiceTest {
 
   private static final String LOBBY_CODE = "ABCDE";
   private static final String USERNAME = "Max";
+  private static final String PLAYER_UUID = "player-uuid";
+  private static final Player PLAYER = new Player(USERNAME, false, PLAYER_UUID);
 
   private GameService gameService;
   private LobbyService lobbyService;
@@ -32,6 +35,7 @@ class CheatServiceTest {
     gameService = mock(GameService.class);
     lobbyService = mock(LobbyService.class);
     cheatService = new CheatService(gameService, lobbyService);
+    when(lobbyService.getPlayer(LOBBY_CODE, USERNAME)).thenReturn(PLAYER);
   }
 
   @Test
@@ -39,8 +43,8 @@ class CheatServiceTest {
     List<Integer> positions = List.of(0, 1);
     CheatResult expected = new CheatResult("Die Karte \"Dog\" ist richtig.", Team.RED);
 
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
     when(gameService.useCheat(LOBBY_CODE, positions, Team.RED)).thenReturn(expected);
 
     CheatResult result = cheatService.useCheat(LOBBY_CODE, USERNAME, positions);
@@ -53,8 +57,8 @@ class CheatServiceTest {
   void useCheatShouldReturnNullWhenTeamIsMissing() {
     List<Integer> positions = List.of(0, 1);
 
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(null);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(null);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
 
     CheatResult result = cheatService.useCheat(LOBBY_CODE, USERNAME, positions);
 
@@ -66,8 +70,8 @@ class CheatServiceTest {
   void useCheatShouldReturnNullWhenPlayerIsNotOperative() {
     List<Integer> positions = List.of(0, 1);
 
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
 
     CheatResult result = cheatService.useCheat(LOBBY_CODE, USERNAME, positions);
 
@@ -77,8 +81,8 @@ class CheatServiceTest {
 
   @Test
   void exposeCheatShouldApplyPenaltyForOperative() {
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
     when(gameService.exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED)).thenReturn(true);
 
     ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
@@ -90,8 +94,8 @@ class CheatServiceTest {
 
   @Test
   void exposeCheatShouldReturnNullWhenTeamIsMissing() {
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(null);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(null);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
 
     ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
 
@@ -101,8 +105,29 @@ class CheatServiceTest {
 
   @Test
   void exposeCheatShouldReturnNullWhenPlayerIsNotOperative() {
-    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
-    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
+    when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
+
+    ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+
+    assertNull(result);
+    verify(gameService, never()).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
+  }
+
+  @Test
+  void useCheatShouldReturnNullWhenPlayerIsMissing() {
+    List<Integer> positions = List.of(0, 1);
+    when(lobbyService.getPlayer(LOBBY_CODE, USERNAME)).thenReturn(null);
+
+    CheatResult result = cheatService.useCheat(LOBBY_CODE, USERNAME, positions);
+
+    assertNull(result);
+    verify(gameService, never()).useCheat(LOBBY_CODE, positions, Team.RED);
+  }
+
+  @Test
+  void exposeCheatShouldReturnNullWhenPlayerIsMissing() {
+    when(lobbyService.getPlayer(LOBBY_CODE, USERNAME)).thenReturn(null);
 
     ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
 

--- a/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
@@ -1,7 +1,9 @@
 package com.codenames.codenames.backend.game.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,5 +73,39 @@ class CheatServiceTest {
 
     assertNull(result);
     verify(gameService, never()).useCheat(LOBBY_CODE, positions, Team.RED);
+  }
+
+  @Test
+  void exposeCheatShouldApplyPenaltyForOperative() {
+    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+    when(gameService.exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED)).thenReturn(true);
+
+    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+
+    assertTrue(result);
+    verify(gameService).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
+  }
+
+  @Test
+  void exposeCheatShouldReturnFalseWhenTeamIsMissing() {
+    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(null);
+    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
+
+    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+
+    assertFalse(result);
+    verify(gameService, never()).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
+  }
+
+  @Test
+  void exposeCheatShouldReturnFalseWhenPlayerIsNotOperative() {
+    when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
+    when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
+
+    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+
+    assertFalse(result);
+    verify(gameService, never()).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
@@ -1,7 +1,6 @@
 package com.codenames.codenames.backend.game.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -10,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codenames.codenames.backend.game.domain.CheatResult;
+import com.codenames.codenames.backend.game.domain.ExposeCheatResult;
 import com.codenames.codenames.backend.lobby.application.LobbyService;
 import com.codenames.codenames.backend.lobby.domain.Role;
 import com.codenames.codenames.backend.lobby.domain.Team;
@@ -81,31 +81,32 @@ class CheatServiceTest {
     when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
     when(gameService.exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED)).thenReturn(true);
 
-    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+    ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
 
-    assertTrue(result);
+    assertTrue(result.correct());
+    assertEquals(Team.RED, result.team());
     verify(gameService).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
   }
 
   @Test
-  void exposeCheatShouldReturnFalseWhenTeamIsMissing() {
+  void exposeCheatShouldReturnNullWhenTeamIsMissing() {
     when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(null);
     when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.OPERATIVE);
 
-    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+    ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
 
-    assertFalse(result);
+    assertNull(result);
     verify(gameService, never()).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
   }
 
   @Test
-  void exposeCheatShouldReturnFalseWhenPlayerIsNotOperative() {
+  void exposeCheatShouldReturnNullWhenPlayerIsNotOperative() {
     when(lobbyService.getPlayerTeam(USERNAME, LOBBY_CODE)).thenReturn(Team.RED);
     when(lobbyService.getPlayerRole(USERNAME, LOBBY_CODE)).thenReturn(Role.SPYMASTER);
 
-    boolean result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
+    ExposeCheatResult result = cheatService.exposeCheat(LOBBY_CODE, USERNAME);
 
-    assertFalse(result);
+    assertNull(result);
     verify(gameService, never()).exposeCheatAndApplyPenalty(LOBBY_CODE, Team.RED);
   }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/CheatServiceTest.java
@@ -41,7 +41,7 @@ class CheatServiceTest {
   @Test
   void useCheatShouldReturnResultForOperative() {
     List<Integer> positions = List.of(0, 1);
-    CheatResult expected = new CheatResult("Die Karte \"Dog\" ist richtig.", Team.RED);
+    CheatResult expected = new CheatResult("The card \"Dog\" belongs to your team.", Team.RED);
 
     when(lobbyService.getPlayerTeam(PLAYER_UUID, LOBBY_CODE)).thenReturn(Team.RED);
     when(lobbyService.getPlayerRole(PLAYER_UUID, LOBBY_CODE)).thenReturn(Role.OPERATIVE);

--- a/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
@@ -163,7 +163,7 @@ class GameServiceTest {
   @Test
   void testUseCheat() {
     List<Integer> positions = List.of(0, 1);
-    CheatResult expected = new CheatResult("Die Karte \"Dog\" ist richtig.", Team.RED);
+    CheatResult expected = new CheatResult("The card \"Dog\" belongs to your team.", Team.RED);
 
     when(mockGameManager.useCheat(positions, redTeam)).thenReturn(expected);
 

--- a/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/application/GameServiceTest.java
@@ -173,4 +173,14 @@ class GameServiceTest {
     assertEquals(expected, result);
     verify(mockGameManager, times(1)).useCheat(positions, redTeam);
   }
+
+  @Test
+  void exposeCheatAndApplyPenaltyShouldDelegateToGameManager() {
+    when(mockGameManager.exposeCheatAndApplyPenalty(redTeam)).thenReturn(true);
+
+    boolean result = gameService.exposeCheatAndApplyPenalty(lobbyCode, redTeam);
+
+    assertTrue(result);
+    verify(mockGameManager, times(1)).exposeCheatAndApplyPenalty(redTeam);
+  }
 }

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
@@ -425,7 +425,7 @@ class GameManagerTest {
 
     CheatResult result = gameManager.useCheat(List.of(0, 1, 2), redTeam);
 
-    assertEquals("Die Karte \"Cat\" ist richtig.", result.message());
+    assertEquals("The card \"Cat\" belongs to your team.", result.message());
     assertTrue(gameManager.isRedTeamCheatUsed());
   }
 
@@ -440,7 +440,7 @@ class GameManagerTest {
 
     CheatResult result = gameManager.useCheat(List.of(0, 1), redTeam);
 
-    assertEquals("Keine der ausgewählten Karten ist richtig.", result.message());
+    assertEquals("None of the selected cards belongs to your team.", result.message());
     assertTrue(gameManager.isRedTeamCheatUsed());
   }
 
@@ -453,7 +453,7 @@ class GameManagerTest {
     CheatResult firstResult = gameManager.useCheat(List.of(0), redTeam);
     CheatResult secondResult = gameManager.useCheat(List.of(0), redTeam);
 
-    assertEquals("Die Karte \"Dog\" ist richtig.", firstResult.message());
+    assertEquals("The card \"Dog\" belongs to your team.", firstResult.message());
     assertNull(secondResult);
   }
 

--- a/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
+++ b/src/test/java/com/codenames/codenames/backend/game/domain/GameManagerTest.java
@@ -1,6 +1,7 @@
 package com.codenames.codenames.backend.game.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -463,5 +464,61 @@ class GameManagerTest {
     CheatResult result = gameManager.useCheat(List.of(-1, 99), redTeam);
 
     assertNull(result);
+  }
+
+  @Test
+  void exposeCheatReturnsTrueWhenOpponentUsedCheat() {
+    GameStateDto state =
+        new GameStateDto(
+            null,
+            Team.RED,
+            Role.OPERATIVE,
+            null,
+            1,
+            List.of(new CardDto("Dog", Color.RED, false)),
+            false,
+            true);
+    GameManager restored = new GameManager(state, mockClueValidationService);
+
+    assertTrue(restored.exposeCheat(Team.RED));
+  }
+
+  @Test
+  void exposeCheatReturnsFalseWhenOpponentDidNotUseCheat() {
+    helperMethodAdvanceTurns(gameManager, 1);
+
+    assertFalse(gameManager.exposeCheat(Team.RED));
+  }
+
+  @Test
+  void exposeCheatAndApplyPenaltyAdvancesTurnWhenCorrect() {
+    GameStateDto state =
+        new GameStateDto(
+            null,
+            Team.RED,
+            Role.OPERATIVE,
+            null,
+            1,
+            List.of(new CardDto("Dog", Color.RED, false)),
+            false,
+            true);
+    GameManager restored = new GameManager(state, mockClueValidationService);
+
+    boolean result = restored.exposeCheatAndApplyPenalty(Team.RED);
+
+    assertTrue(result);
+    assertEquals(Team.RED, restored.getCurrentTurn());
+    assertEquals(Role.SPYMASTER, restored.getCurrentPhase());
+  }
+
+  @Test
+  void exposeCheatAndApplyPenaltyPassesTurnWhenWrong() {
+    helperMethodAdvanceTurns(gameManager, 1);
+
+    boolean result = gameManager.exposeCheatAndApplyPenalty(Team.RED);
+
+    assertFalse(result);
+    assertEquals(Team.BLUE, gameManager.getCurrentTurn());
+    assertEquals(Role.SPYMASTER, gameManager.getCurrentPhase());
   }
 }


### PR DESCRIPTION
## Context
Adds backend cheat detection support for operative gameplay and cheat exposure handling.

## Description
Implemented cheat usage and expose-cheat backend flow via WebSocket. Operatives can use cheat support during their phase, and teams can expose opponent cheating with turn penalties applied based on the result.

## Changes in the codebase
Added expose-cheat WebSocket endpoint
Added cheat exposure result DTO
Added cheat validation through CheatService
Resolved player team and role via player UUID
Added opponent turn skip on correct cheat exposure
Added turn pass penalty on wrong cheat exposure
Added operative chat system messages for expose results
Added/updated tests for GameManager, GameService, CheatService, and GameSocketController

## Changes outside the codebase
N/A

## Additional information
Cheat actions are limited to operatives. Correct exposure skips the opposing team’s next turn, while wrong exposure ends the accusing team’s turn.